### PR TITLE
Provide handler to remove border for frameless windows (Win32 only)

### DIFF
--- a/atom/browser/native_window_views.cc
+++ b/atom/browser/native_window_views.cc
@@ -167,8 +167,8 @@ NativeWindowViews::NativeWindowViews(
 
   if (enable_larger_than_screen())
     // We need to set a default maximum window size here otherwise Windows
-    // will not allow us to resize the window larger than scree.
-    // Setting directly to INT_MAX somehow doesn't work, so we just devide
+    // will not allow us to resize the window larger than screen.
+    // Setting directly to INT_MAX somehow doesn't work, so we just divide
     // by 10, which should still be large enough.
     SetContentSizeConstraints(extensions::SizeConstraints(
         gfx::Size(), gfx::Size(INT_MAX / 10, INT_MAX / 10)));
@@ -201,6 +201,19 @@ NativeWindowViews::NativeWindowViews(
     params.activatable = views::Widget::InitParams::ACTIVATABLE_NO;
 
 #if defined(OS_WIN)
+  /** Registers handlers used to:
+   *  - listen for windows events via PreHandleMSG
+   *    - events include WM_GETOBJECT / WM_COMMAND / WM_SIZE / WM_MOVING / WM_MOVE
+   *    - \see src/electron/atom/browser/native_window_views_win.cc
+   *  - override the client area inset
+   *    - used to force border of 0 for frameless windows
+   *    - \see src/electron/atom/browser/ui/win/atom_desktop_window_tree_host_win.cc
+   *
+   *  Important things to note:
+   *  - views::Widget is located in Chromium at src/ui/views/widget/widget.cc
+   *  - Widget acts as a proxy for DesktopNativeWidgetAura (it passes calls through)
+   *  - DesktopNativeWidgetAura then calls AtomDesktopWindowTreeHostWin as needed
+   */
   if (parent)
     params.parent = parent->GetNativeWindow();
 

--- a/atom/browser/ui/win/atom_desktop_window_tree_host_win.cc
+++ b/atom/browser/ui/win/atom_desktop_window_tree_host_win.cc
@@ -19,10 +19,21 @@ AtomDesktopWindowTreeHostWin::AtomDesktopWindowTreeHostWin(
 
 AtomDesktopWindowTreeHostWin::~AtomDesktopWindowTreeHostWin() {
 }
-
+/** Route Windows messages to delegate (NativeWindowViews)
+ *  \see src/electron/atom/browser/native_window_views_win.cc
+ *  \see src/electron/atom/browser/native_window_views.cc
+ */
 bool AtomDesktopWindowTreeHostWin::PreHandleMSG(
     UINT message, WPARAM w_param, LPARAM l_param, LRESULT* result) {
   return delegate_->PreHandleMSG(message, w_param, l_param, result);
+}
+
+/** Override the client area inset
+ *  Returning true forces a border of 0 for frameless windows
+ */
+bool AtomDesktopWindowTreeHostWin::GetClientAreaInsets(
+    gfx::Insets* insets) const {
+  return !HasFrame();
 }
 
 }  // namespace atom

--- a/atom/browser/ui/win/atom_desktop_window_tree_host_win.h
+++ b/atom/browser/ui/win/atom_desktop_window_tree_host_win.h
@@ -27,6 +27,7 @@ class AtomDesktopWindowTreeHostWin : public views::DesktopWindowTreeHostWin {
  protected:
   bool PreHandleMSG(
       UINT message, WPARAM w_param, LPARAM l_param, LRESULT* result) override;
+  bool GetClientAreaInsets(gfx::Insets* insets) const override;
 
  private:
   MessageHandlerDelegate* delegate_;  // weak ref


### PR DESCRIPTION
Provide handler to remove border for frameless windows (Win32 only)

Fixes https://github.com/brave/browser-laptop/issues/6258

Auditors: @bbondy, @bridiver