### PR TITLE
remove script/build.py references from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
   "private": true,
   "scripts": {
     "bootstrap": "python ./script/bootstrap.py",
-    "build": "python ./script/build.py -c D",
     "clean": "python ./script/clean.py",
     "coverage": "npm run instrument-code-coverage && npm test -- --use-instrumented-asar",
     "instrument-code-coverage": "electabul instrument --input-path ./lib --output-path ./out/coverage/electron.asar",
@@ -43,9 +42,6 @@
     "cibuild-windows": "rm -Rf node_mdules && python ./script/cibuild --target_arch=x64",
     "cibuild-windows-ia32": "rm -Rf node_mdules && python ./script/cibuild --target_arch=ia32",
     "test": "python ./script/test.py",
-    "browser-build": "npm run build && rsync -avz --delete out/D/Brave.app ../browser-laptop/node_modules/electron-prebuilt/dist/",
-    "browser-build-linux": "python ./script/build.py -c R && rsync -avz --delete out/R/ ../browser-laptop/node_modules/electron-prebuilt/dist/",
-    "browser-build-windows": "python ./script/build.py -c R && xcopy .\\out\\R\\* ..\\browser-laptop\\node_modules\\electron-prebuilt\\dist\\ /Y /S /I /F /R",
     "libchromium-build": "python ../libchromiumcontent/script/bootstrap && python ../libchromiumcontent/script/update && python ../libchromiumcontent/script/build && python ../libchromiumcontent/script/create-dist --no_zip",
     "libchromium-bootstrap": "python ./script/bootstrap.py -v --libcc_source_path ../libchromiumcontent/dist/main/src --libcc_shared_library_path ../libchromiumcontent/dist/main/shared_library --libcc_static_library_path ../libchromiumcontent/dist/main/static_library"
   }


### PR DESCRIPTION
for #132

now that `./script/build.py` no longer exists, the associated `package.json` scripts should be removed:
- `npm run build`
- `npm run browser-build`
- etc

cc @bsclifton 