### PR TITLE
Fix exception of couldn't delay loading ole32.dll

### DIFF
--- a/app/win/BUILD.gn
+++ b/app/win/BUILD.gn
@@ -73,7 +73,6 @@ executable("electron_app") {
   ldflags = [
     "/DELAYLOAD:dbghelp.dll",
     "/DELAYLOAD:uxtheme.dll",
-    "/DELAYLOAD:ole32.dll",
     "/DELAYLOAD:oleaut32.dll",
     "/DELAYLOAD:comdlg32.dll",
     "/DELAYLOAD:crypt32.dll",


### PR DESCRIPTION
fix https://github.com/brave/browser-laptop/issues/6522

Auditors: @bbondy, @bridiver, @bsclifton (summon three Brian in a row)