### PR TITLE
Fix for rounded border issue on 200% DPI (Windows).

### DIFF
--- a/atom/browser/native_window_views_win.cc
+++ b/atom/browser/native_window_views_win.cc
@@ -130,18 +130,6 @@ bool NativeWindowViews::PreHandleMSG(
       }
       return false;
     }
-    /** Return zero (no-op) for non-client area events when window is frameless.
-     *  \see WM_NCPAINT - https://msdn.microsoft.com/en-us/library/windows/desktop/dd145212(v=vs.85).aspx
-     *  \see WM_NCCALCSIZE - https://msdn.microsoft.com/en-us/library/windows/desktop/ms632634(v=vs.85).aspx
-     */
-    case WM_NCPAINT:
-    case WM_NCCALCSIZE: {
-      if (!has_frame()) {
-        *result = 0;
-        return true;
-      }
-      return false;
-    }
     default:
       return false;
   }

--- a/atom/browser/ui/win/atom_desktop_window_tree_host_win.cc
+++ b/atom/browser/ui/win/atom_desktop_window_tree_host_win.cc
@@ -28,4 +28,12 @@ bool AtomDesktopWindowTreeHostWin::PreHandleMSG(
   return delegate_->PreHandleMSG(message, w_param, l_param, result);
 }
 
+/** Override the client area inset
+ *  Returning true forces a border of 0 for frameless windows
+ */
+bool AtomDesktopWindowTreeHostWin::GetClientAreaInsets(
+    gfx::Insets* insets) const {
+  return !HasFrame();
+}
+
 }  // namespace atom

--- a/atom/browser/ui/win/atom_desktop_window_tree_host_win.h
+++ b/atom/browser/ui/win/atom_desktop_window_tree_host_win.h
@@ -27,6 +27,7 @@ class AtomDesktopWindowTreeHostWin : public views::DesktopWindowTreeHostWin {
  protected:
   bool PreHandleMSG(
       UINT message, WPARAM w_param, LPARAM l_param, LRESULT* result) override;
+  bool GetClientAreaInsets(gfx::Insets* insets) const override;
 
  private:
   MessageHandlerDelegate* delegate_;  // weak ref


### PR DESCRIPTION
Was noticed when upstreaming border fixes to electron with https://github.com/electron/electron/pull/8404
After @kevinsawicki saw same issue, I fixed with https://github.com/electron/electron/pull/8404/commits/9e0547b98f8b7f3a572aa1cf9770f434c8fdeed9 (same as this fix)

Tested on Windows 10 anniversary edition at 200% DPI and confirmed issue is fixed with this

Fixes https://github.com/brave/browser-laptop/issues/4216

Auditors: @bbondy, @darkdh, @bridiver