### PR TITLE
Cherry-pick "Save a copy when advancing to dependent GIF and WebP animation frames"

### DIFF
--- a/patches/master_patch.patch
+++ b/patches/master_patch.patch
@@ -2239,6 +2239,301 @@ index f002ab60b88a8c8f2c9d1676eaba37e12b84ebbe..6343541674bf63f121f4ebc9959a3071
    ]
  }
 +}
+diff --git a/third_party/WebKit/LayoutTests/canvas/philip/tests/2d.pattern.image.string-expected.txt b/third_party/WebKit/LayoutTests/canvas/philip/tests/2d.pattern.image.string-expected.txt
+index 179897237ccc0d6c7f7f33b4b2640c1661d3af74..0b1ad080a18c9986729844703a6e7d1fbf94c27b 100644
+--- a/third_party/WebKit/LayoutTests/canvas/philip/tests/2d.pattern.image.string-expected.txt
++++ b/third_party/WebKit/LayoutTests/canvas/philip/tests/2d.pattern.image.string-expected.txt
+@@ -1 +1 @@
+-Failed assertion: expected exception of type TYPE_MISMATCH_ERR, got: Failed to execute 'createPattern' on 'CanvasRenderingContext2D': The provided value is not of type '(HTMLImageElement or HTMLVideoElement or HTMLCanvasElement or ImageBitmap)'
++Failed assertion: expected exception of type TYPE_MISMATCH_ERR, got: Failed to execute 'createPattern' on 'CanvasRenderingContext2D': The provided value is not of type '(HTMLImageElement or HTMLVideoElement or HTMLCanvasElement or ImageBitmap or OffscreenCanvas)'
+diff --git a/third_party/WebKit/LayoutTests/canvas/philip/tests/2d.pattern.image.undefined-expected.txt b/third_party/WebKit/LayoutTests/canvas/philip/tests/2d.pattern.image.undefined-expected.txt
+index 179897237ccc0d6c7f7f33b4b2640c1661d3af74..0b1ad080a18c9986729844703a6e7d1fbf94c27b 100644
+--- a/third_party/WebKit/LayoutTests/canvas/philip/tests/2d.pattern.image.undefined-expected.txt
++++ b/third_party/WebKit/LayoutTests/canvas/philip/tests/2d.pattern.image.undefined-expected.txt
+@@ -1 +1 @@
+-Failed assertion: expected exception of type TYPE_MISMATCH_ERR, got: Failed to execute 'createPattern' on 'CanvasRenderingContext2D': The provided value is not of type '(HTMLImageElement or HTMLVideoElement or HTMLCanvasElement or ImageBitmap)'
++Failed assertion: expected exception of type TYPE_MISMATCH_ERR, got: Failed to execute 'createPattern' on 'CanvasRenderingContext2D': The provided value is not of type '(HTMLImageElement or HTMLVideoElement or HTMLCanvasElement or ImageBitmap or OffscreenCanvas)'
+diff --git a/third_party/WebKit/LayoutTests/fast/canvas/OffscreenCanvas-2d-drawImage-expected.html b/third_party/WebKit/LayoutTests/fast/canvas/OffscreenCanvas-2d-drawImage-expected.html
+index 89e26a06369ee074fca1a55544e1fa11cfb691e6..c09dbc71b4025e5e29b4e56caa43819a6503bbd6 100644
+--- a/third_party/WebKit/LayoutTests/fast/canvas/OffscreenCanvas-2d-drawImage-expected.html
++++ b/third_party/WebKit/LayoutTests/fast/canvas/OffscreenCanvas-2d-drawImage-expected.html
+@@ -13,6 +13,8 @@
+ <canvas id="videoOutput" width="150" height="150"></canvas>
+ <canvas id="imageOutput" width="150" height="150"></canvas>
+ <canvas id="canvasOutput" width="150" height="150"></canvas>
++<canvas id="offscreenCanvas2DOutput" width="150" height="150"></canvas>
++<canvas id="offscreenCanvasWebGLOutput" width="150" height="150"></canvas>
+ 
+ <script>
+ function drawImageSourceToHTMLCanvas(imageSource, outputCanvas) { 
+@@ -55,6 +57,17 @@ htmlCanvasCtx.fillStyle = "red";
+ htmlCanvasCtx.fillRect(15, 0, 30, 30);
+ drawImageSourceToHTMLCanvas(htmlCanvas, document.getElementById('canvasOutput'));
+ 
++// Assume html and offscreen canvases should yield identical results
++drawImageSourceToHTMLCanvas(htmlCanvas, document.getElementById('offscreenCanvas2DOutput'));
++
++// Image source as OffscreenCanvas with webGL context
++var glCanvas = document.createElement('canvas');
++glCanvas.width = glCanvas.height = 30;
++var gl = glCanvas.getContext("webgl");
++gl.clearColor(0.0, 0.0, 1.0, 1.0);
++gl.clear(gl.COLOR_BUFFER_BIT);
++drawImageSourceToHTMLCanvas(glCanvas, document.getElementById('offscreenCanvasWebGLOutput'));
++
+ </script>
+ </body>
+ 
+diff --git a/third_party/WebKit/LayoutTests/fast/canvas/OffscreenCanvas-2d-drawImage.html b/third_party/WebKit/LayoutTests/fast/canvas/OffscreenCanvas-2d-drawImage.html
+index f4e1a1c045cc5a37ba8f76297e20a1b45be89635..f62058299c1f9552715021ea2ec66df53c758ad3 100644
+--- a/third_party/WebKit/LayoutTests/fast/canvas/OffscreenCanvas-2d-drawImage.html
++++ b/third_party/WebKit/LayoutTests/fast/canvas/OffscreenCanvas-2d-drawImage.html
+@@ -13,6 +13,8 @@
+ <canvas id="videoOutput" width="150" height="150"></canvas>
+ <canvas id="imageOutput" width="150" height="150"></canvas>
+ <canvas id="canvasOutput" width="150" height="150"></canvas>
++<canvas id="offscreenCanvas2DOutput" width="150" height="150"></canvas>
++<canvas id="offscreenCanvasWebGLOutput" width="150" height="150"></canvas>
+ 
+ <script>
+ function drawImageSourceToOffscreenCanvas(imageSource, outputCanvas) {
+@@ -59,6 +61,22 @@ htmlCanvasCtx.fillStyle = "red";
+ htmlCanvasCtx.fillRect(15, 0, 30, 30);
+ drawImageSourceToOffscreenCanvas(htmlCanvas, document.getElementById('canvasOutput'));
+ 
++// image source as OffscreenCanvas with 2D context
++var offscreenCanvas2D = new OffscreenCanvas(30, 30);
++var offscreenCanvas2DCtx = offscreenCanvas2D.getContext("2d");
++offscreenCanvas2DCtx.fillStyle = "blue";
++offscreenCanvas2DCtx.fillRect(0, 0, 15, 30);
++offscreenCanvas2DCtx.fillStyle = "red";
++offscreenCanvas2DCtx.fillRect(15, 0, 30, 30);
++drawImageSourceToOffscreenCanvas(offscreenCanvas2D, document.getElementById('offscreenCanvas2DOutput'));
++
++// Image source as OffscreenCanvas with webGL context
++var offscreenCanvasWebGL = new OffscreenCanvas(30, 30);
++var gl = offscreenCanvasWebGL.getContext("webgl");
++gl.clearColor(0.0, 0.0, 1.0, 1.0);
++gl.clear(gl.COLOR_BUFFER_BIT);
++drawImageSourceToOffscreenCanvas(offscreenCanvasWebGL, document.getElementById('offscreenCanvasWebGLOutput'));
++
+ </script>
+ </body>
+ 
+diff --git a/third_party/WebKit/LayoutTests/fast/canvas/OffscreenCanvas-2d-pattern-in-worker.html b/third_party/WebKit/LayoutTests/fast/canvas/OffscreenCanvas-2d-pattern-in-worker.html
+index 4d43564d11c017d397ca852d1c08e9498d6a4194..8772383b48bdefde3839e92da78a66eedec1f86f 100644
+--- a/third_party/WebKit/LayoutTests/fast/canvas/OffscreenCanvas-2d-pattern-in-worker.html
++++ b/third_party/WebKit/LayoutTests/fast/canvas/OffscreenCanvas-2d-pattern-in-worker.html
+@@ -4,10 +4,21 @@
+ <canvas id='output' width='150' height='150'></canvas>
+ <script id='myWorker' type='text/worker'>
+ self.onmessage = function(e) {
++    var patternCanvas = new OffscreenCanvas(30, 30);
++    var patternCtx = patternCanvas.getContext('2d');        
++    patternCtx.fillStyle = '#f00';                                                     
++    patternCtx.fillRect(0, 0, 15, 15);                                              
++    patternCtx.fillStyle = '#0f0';                                                     
++    patternCtx.fillRect(15, 0, 15, 15);                                             
++    patternCtx.fillStyle = '#00f';
++    patternCtx.fillRect(0, 15, 15, 15);
++    patternCtx.fillStyle = "#ff0";
++    patternCtx.fillRect(15, 15, 15, 15);
++
+     var aCanvas = new OffscreenCanvas(150, 150);
+     var ctx = aCanvas.getContext('2d');
+    
+-    var myPattern = ctx.createPattern(e.data, 'repeat');
++    var myPattern = ctx.createPattern(patternCanvas, 'repeat');
+     ctx.fillStyle = myPattern;
+     ctx.fillRect(0, 0, aCanvas.width, aCanvas.height);
+ 
+@@ -20,32 +31,16 @@ if (window.testRunner) {
+   testRunner.waitUntilDone();
+ }
+ 
+-var patternCanvas = document.createElement('canvas');
+-patternCanvas.width = 30;
+-patternCanvas.height = 30;
+-var patternCtx = patternCanvas.getContext('2d');        
+-patternCtx.fillStyle = '#f00';                                                     
+-patternCtx.fillRect(0, 0, 15, 15);                                              
+-patternCtx.fillStyle = '#0f0';                                                     
+-patternCtx.fillRect(15, 0, 15, 15);                                             
+-patternCtx.fillStyle = '#00f';
+-patternCtx.fillRect(0, 15, 15, 15);
+-patternCtx.fillStyle = "#ff0";
+-patternCtx.fillRect(15, 15, 15, 15);
+-createImageBitmap(patternCanvas).then(consumeImageBitmap);
+-
+-function consumeImageBitmap(patternImage) {
+-    var blob = new Blob([document.getElementById('myWorker').textContent]);
+-    var worker = new Worker(URL.createObjectURL(blob));
+-    worker.addEventListener('message', msg => {
+-      var outputCtx = document.getElementById('output').getContext('bitmaprenderer');
+-      outputCtx.transferFromImageBitmap(msg.data);
+-      if (window.testRunner) {
+-        testRunner.notifyDone();
+-      }
+-    });
+-    worker.postMessage(patternImage, [patternImage]);
+-}
++var blob = new Blob([document.getElementById('myWorker').textContent]);
++var worker = new Worker(URL.createObjectURL(blob));
++worker.addEventListener('message', msg => {
++  var outputCtx = document.getElementById('output').getContext('bitmaprenderer');
++  outputCtx.transferFromImageBitmap(msg.data);
++  if (window.testRunner) {
++    testRunner.notifyDone();
++  }
++});
++worker.postMessage("go");
+ </script>
+ </body>
+ 
+diff --git a/third_party/WebKit/LayoutTests/fast/canvas/OffscreenCanvas-transferable-exceptions-expected.txt b/third_party/WebKit/LayoutTests/fast/canvas/OffscreenCanvas-transferable-exceptions-expected.txt
+index cc00da90ee792cbb071c17ea7ea2257779d0a0b2..80ad9481c1503fb9bedee1d69861745ceaba17e1 100644
+--- a/third_party/WebKit/LayoutTests/fast/canvas/OffscreenCanvas-transferable-exceptions-expected.txt
++++ b/third_party/WebKit/LayoutTests/fast/canvas/OffscreenCanvas-transferable-exceptions-expected.txt
+@@ -9,6 +9,7 @@ PASS worker.postMessage({data: offscreenCanvas1}, [offscreenCanvas1]) threw exce
+ PASS offscreenCanvas2.transferToImageBitmap() threw exception InvalidStateError: Failed to execute 'transferToImageBitmap' on 'OffscreenCanvas': Cannot transfer an ImageBitmap from a detached OffscreenCanvas.
+ PASS worker.postMessage({data: offscreenCanvas2}, [offscreenCanvas2]) threw exception DataCloneError: Failed to execute 'postMessage' on 'Worker': An OffscreenCanvas is detached and could not be cloned..
+ PASS offscreenCanvas2.getContext('2d') threw exception InvalidStateError: Failed to execute 'getContext' on 'OffscreenCanvas': OffscreenCanvas object is detached.
++PASS ctx.drawImage(offscreenCanvas2, 0, 0) threw exception InvalidStateError: Failed to execute 'drawImage' on 'OffscreenCanvasRenderingContext2D': The image source is detached.
+ PASS successfullyParsed is true
+ 
+ TEST COMPLETE
+diff --git a/third_party/WebKit/LayoutTests/fast/canvas/OffscreenCanvas-transferable-exceptions.html b/third_party/WebKit/LayoutTests/fast/canvas/OffscreenCanvas-transferable-exceptions.html
+index 18dc0b0a6fc17fa6804a5b67de29b92a75fe1adc..97944a2caba6c0c0cb200f9df19fc7bcb9968acc 100644
+--- a/third_party/WebKit/LayoutTests/fast/canvas/OffscreenCanvas-transferable-exceptions.html
++++ b/third_party/WebKit/LayoutTests/fast/canvas/OffscreenCanvas-transferable-exceptions.html
+@@ -26,6 +26,9 @@ shouldThrow("offscreenCanvas2.transferToImageBitmap()");
+ shouldThrow("worker.postMessage({data: offscreenCanvas2}, [offscreenCanvas2])");
+ shouldThrow("offscreenCanvas2.getContext('2d')");
+ 
++// using a transferred OffscreenCanvas as a source image throws.
++shouldThrow("ctx.drawImage(offscreenCanvas2, 0, 0)");
++
+ finishJSTest();
+ </script>
+ </body>
+diff --git a/third_party/WebKit/LayoutTests/fast/canvas/canvas-pattern-behaviour-expected.txt b/third_party/WebKit/LayoutTests/fast/canvas/canvas-pattern-behaviour-expected.txt
+index 5ed3b3144e0811e3ac33feafa355be9c21e0c97e..19ca0fc29354185166c7de720b7ebbda7c3eee50 100644
+--- a/third_party/WebKit/LayoutTests/fast/canvas/canvas-pattern-behaviour-expected.txt
++++ b/third_party/WebKit/LayoutTests/fast/canvas/canvas-pattern-behaviour-expected.txt
+@@ -12,10 +12,10 @@ PASS context.createPattern(green1x1, 'null') threw exception SyntaxError: Failed
+ PASS context.createPattern(green1x1, undefined) threw exception SyntaxError: Failed to execute 'createPattern' on 'CanvasRenderingContext2D': The provided type ('undefined') is not one of 'repeat', 'no-repeat', 'repeat-x', or 'repeat-y'..
+ PASS context.createPattern(green1x1, 'undefined') threw exception SyntaxError: Failed to execute 'createPattern' on 'CanvasRenderingContext2D': The provided type ('undefined') is not one of 'repeat', 'no-repeat', 'repeat-x', or 'repeat-y'..
+ PASS context.createPattern(green1x1, {toString:function(){ return null;}}) threw exception SyntaxError: Failed to execute 'createPattern' on 'CanvasRenderingContext2D': The provided type ('null') is not one of 'repeat', 'no-repeat', 'repeat-x', or 'repeat-y'..
+-PASS context.createPattern(null, '') threw exception TypeError: Failed to execute 'createPattern' on 'CanvasRenderingContext2D': The provided value is not of type '(HTMLImageElement or HTMLVideoElement or HTMLCanvasElement or ImageBitmap)'.
+-PASS context.createPattern(undefined, '') threw exception TypeError: Failed to execute 'createPattern' on 'CanvasRenderingContext2D': The provided value is not of type '(HTMLImageElement or HTMLVideoElement or HTMLCanvasElement or ImageBitmap)'.
+-PASS context.createPattern({}, '') threw exception TypeError: Failed to execute 'createPattern' on 'CanvasRenderingContext2D': The provided value is not of type '(HTMLImageElement or HTMLVideoElement or HTMLCanvasElement or ImageBitmap)'.
+-PASS context.createPattern([], '') threw exception TypeError: Failed to execute 'createPattern' on 'CanvasRenderingContext2D': The provided value is not of type '(HTMLImageElement or HTMLVideoElement or HTMLCanvasElement or ImageBitmap)'.
++PASS context.createPattern(null, '') threw exception TypeError: Failed to execute 'createPattern' on 'CanvasRenderingContext2D': The provided value is not of type '(HTMLImageElement or HTMLVideoElement or HTMLCanvasElement or ImageBitmap or OffscreenCanvas)'.
++PASS context.createPattern(undefined, '') threw exception TypeError: Failed to execute 'createPattern' on 'CanvasRenderingContext2D': The provided value is not of type '(HTMLImageElement or HTMLVideoElement or HTMLCanvasElement or ImageBitmap or OffscreenCanvas)'.
++PASS context.createPattern({}, '') threw exception TypeError: Failed to execute 'createPattern' on 'CanvasRenderingContext2D': The provided value is not of type '(HTMLImageElement or HTMLVideoElement or HTMLCanvasElement or ImageBitmap or OffscreenCanvas)'.
++PASS context.createPattern([], '') threw exception TypeError: Failed to execute 'createPattern' on 'CanvasRenderingContext2D': The provided value is not of type '(HTMLImageElement or HTMLVideoElement or HTMLCanvasElement or ImageBitmap or OffscreenCanvas)'.
+ PASS context.createPattern(green1x1, '') did not throw an exception
+ PASS getPixel(1,1) is [0,128,0,255]
+ PASS getPixel(98,1) is [0,128,0,255]
+diff --git a/third_party/WebKit/LayoutTests/fast/canvas/drawImage-with-broken-image-expected.txt b/third_party/WebKit/LayoutTests/fast/canvas/drawImage-with-broken-image-expected.txt
+index cdebf4db1cde25cfdd92512a03cbe7e7ba14bf83..d113cf592710b7e6cfe8eec1a68c0504365a61d2 100644
+--- a/third_party/WebKit/LayoutTests/fast/canvas/drawImage-with-broken-image-expected.txt
++++ b/third_party/WebKit/LayoutTests/fast/canvas/drawImage-with-broken-image-expected.txt
+@@ -3,12 +3,12 @@ This test checks behavior of Canvas::drawImage with a broken source image.
+ On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+ 
+ 
+-PASS ctx.drawImage(null, 0, 0) threw exception TypeError: Failed to execute 'drawImage' on 'CanvasRenderingContext2D': The provided value is not of type '(HTMLImageElement or HTMLVideoElement or HTMLCanvasElement or ImageBitmap)'.
+-PASS ctx.drawImage(null, 0, 0, 20, 20) threw exception TypeError: Failed to execute 'drawImage' on 'CanvasRenderingContext2D': The provided value is not of type '(HTMLImageElement or HTMLVideoElement or HTMLCanvasElement or ImageBitmap)'.
+-PASS ctx.drawImage(null, 0, 0, 20, 20, 0, 0, 20, 20) threw exception TypeError: Failed to execute 'drawImage' on 'CanvasRenderingContext2D': The provided value is not of type '(HTMLImageElement or HTMLVideoElement or HTMLCanvasElement or ImageBitmap)'.
+-PASS ctx.drawImage(undefined, 0, 0) threw exception TypeError: Failed to execute 'drawImage' on 'CanvasRenderingContext2D': The provided value is not of type '(HTMLImageElement or HTMLVideoElement or HTMLCanvasElement or ImageBitmap)'.
+-PASS ctx.drawImage(undefined, 0, 0, 20, 20) threw exception TypeError: Failed to execute 'drawImage' on 'CanvasRenderingContext2D': The provided value is not of type '(HTMLImageElement or HTMLVideoElement or HTMLCanvasElement or ImageBitmap)'.
+-PASS ctx.drawImage(undefined, 0, 0, 20, 20, 0, 0, 20, 20) threw exception TypeError: Failed to execute 'drawImage' on 'CanvasRenderingContext2D': The provided value is not of type '(HTMLImageElement or HTMLVideoElement or HTMLCanvasElement or ImageBitmap)'.
++PASS ctx.drawImage(null, 0, 0) threw exception TypeError: Failed to execute 'drawImage' on 'CanvasRenderingContext2D': The provided value is not of type '(HTMLImageElement or HTMLVideoElement or HTMLCanvasElement or ImageBitmap or OffscreenCanvas)'.
++PASS ctx.drawImage(null, 0, 0, 20, 20) threw exception TypeError: Failed to execute 'drawImage' on 'CanvasRenderingContext2D': The provided value is not of type '(HTMLImageElement or HTMLVideoElement or HTMLCanvasElement or ImageBitmap or OffscreenCanvas)'.
++PASS ctx.drawImage(null, 0, 0, 20, 20, 0, 0, 20, 20) threw exception TypeError: Failed to execute 'drawImage' on 'CanvasRenderingContext2D': The provided value is not of type '(HTMLImageElement or HTMLVideoElement or HTMLCanvasElement or ImageBitmap or OffscreenCanvas)'.
++PASS ctx.drawImage(undefined, 0, 0) threw exception TypeError: Failed to execute 'drawImage' on 'CanvasRenderingContext2D': The provided value is not of type '(HTMLImageElement or HTMLVideoElement or HTMLCanvasElement or ImageBitmap or OffscreenCanvas)'.
++PASS ctx.drawImage(undefined, 0, 0, 20, 20) threw exception TypeError: Failed to execute 'drawImage' on 'CanvasRenderingContext2D': The provided value is not of type '(HTMLImageElement or HTMLVideoElement or HTMLCanvasElement or ImageBitmap or OffscreenCanvas)'.
++PASS ctx.drawImage(undefined, 0, 0, 20, 20, 0, 0, 20, 20) threw exception TypeError: Failed to execute 'drawImage' on 'CanvasRenderingContext2D': The provided value is not of type '(HTMLImageElement or HTMLVideoElement or HTMLCanvasElement or ImageBitmap or OffscreenCanvas)'.
+ PASS ctx.drawImage(invalidImage, 0, 0) threw exception InvalidStateError: Failed to execute 'drawImage' on 'CanvasRenderingContext2D': The HTMLImageElement provided is in the 'broken' state..
+ PASS ctx.drawImage(invalidImage, 0, 0, 20, 20) threw exception InvalidStateError: Failed to execute 'drawImage' on 'CanvasRenderingContext2D': The HTMLImageElement provided is in the 'broken' state..
+ PASS ctx.drawImage(invalidImage, 0, 0, 20, 20, 0, 0, 20, 20) threw exception InvalidStateError: Failed to execute 'drawImage' on 'CanvasRenderingContext2D': The HTMLImageElement provided is in the 'broken' state..
+diff --git a/third_party/WebKit/Source/bindings/modules/v8/generated.gni b/third_party/WebKit/Source/bindings/modules/v8/generated.gni
+index 7d2ba8db8aa8b886526a5ef1f98b7cb38e011abe..0dcfce93b172ea64ed543fbef6d09f7e41c83f28 100644
+--- a/third_party/WebKit/Source/bindings/modules/v8/generated.gni
++++ b/third_party/WebKit/Source/bindings/modules/v8/generated.gni
+@@ -123,8 +123,8 @@ bindings_modules_generated_union_type_files = [
+   "$bindings_modules_v8_output_dir/FormDataOrURLSearchParams.h",
+   "$bindings_modules_v8_output_dir/HTMLCanvasElementOrOffscreenCanvas.cpp",
+   "$bindings_modules_v8_output_dir/HTMLCanvasElementOrOffscreenCanvas.h",
+-  "$bindings_modules_v8_output_dir/HTMLImageElementOrHTMLVideoElementOrHTMLCanvasElementOrImageBitmap.cpp",
+-  "$bindings_modules_v8_output_dir/HTMLImageElementOrHTMLVideoElementOrHTMLCanvasElementOrImageBitmap.h",
++  "$bindings_modules_v8_output_dir/HTMLImageElementOrHTMLVideoElementOrHTMLCanvasElementOrImageBitmapOrOffscreenCanvas.cpp",
++  "$bindings_modules_v8_output_dir/HTMLImageElementOrHTMLVideoElementOrHTMLCanvasElementOrImageBitmapOrOffscreenCanvas.h",
+   "$bindings_modules_v8_output_dir/LongOrConstrainLongRange.cpp",
+   "$bindings_modules_v8_output_dir/LongOrConstrainLongRange.h",
+   "$bindings_modules_v8_output_dir/OffscreenCanvasRenderingContext2DOrWebGLRenderingContextOrWebGL2RenderingContext.cpp",
+diff --git a/third_party/WebKit/Source/core/animation/Keyframe.h b/third_party/WebKit/Source/core/animation/Keyframe.h
+index cafa26f71da35b072c0b737d255c3f739c01a686..1d17bcc3063e35c1a47cbd6161c2e46e5db76eab 100644
+--- a/third_party/WebKit/Source/core/animation/Keyframe.h
++++ b/third_party/WebKit/Source/core/animation/Keyframe.h
+@@ -73,7 +73,7 @@ public:
+ 
+         // FIXME: Remove this once CompositorAnimations no longer depends on AnimatableValues
+         virtual bool populateAnimatableValue(CSSPropertyID, Element&, const ComputedStyle& baseStyle, const ComputedStyle* parentStyle) const { return false; }
+-        virtual const PassRefPtr<AnimatableValue> getAnimatableValue() const = 0;
++        virtual PassRefPtr<AnimatableValue> getAnimatableValue() const = 0;
+ 
+         virtual bool isAnimatableValuePropertySpecificKeyframe() const { return false; }
+         virtual bool isCSSPropertySpecificKeyframe() const { return false; }
+diff --git a/third_party/WebKit/Source/core/animation/StringKeyframe.h b/third_party/WebKit/Source/core/animation/StringKeyframe.h
+index bf7beae52b59fee6a766b5901ff24b141b97b161..bcf41220321d038d9448a3f2aa90e93ea1275ffb 100644
+--- a/third_party/WebKit/Source/core/animation/StringKeyframe.h
++++ b/third_party/WebKit/Source/core/animation/StringKeyframe.h
+@@ -58,7 +58,7 @@ public:
+         const CSSValue* value() const { return m_value.get(); }
+ 
+         bool populateAnimatableValue(CSSPropertyID, Element&, const ComputedStyle& baseStyle, const ComputedStyle* parentStyle) const final;
+-        const PassRefPtr<AnimatableValue> getAnimatableValue() const final { return m_animatableValueCache.get(); }
++        PassRefPtr<AnimatableValue> getAnimatableValue() const final { return m_animatableValueCache.get(); }
+         void setAnimatableValue(PassRefPtr<AnimatableValue> value) { m_animatableValueCache = value; }
+ 
+         bool isNeutral() const final { return !m_value; }
+@@ -91,7 +91,7 @@ public:
+ 
+         PassRefPtr<PropertySpecificKeyframe> cloneWithOffset(double offset) const final;
+ 
+-        const PassRefPtr<AnimatableValue> getAnimatableValue() const final { return nullptr; }
++        PassRefPtr<AnimatableValue> getAnimatableValue() const final { return nullptr; }
+ 
+         bool isNeutral() const final { return m_value.isNull(); }
+         PassRefPtr<PropertySpecificKeyframe> neutralKeyframe(double offset, PassRefPtr<TimingFunction> easing) const final;
+diff --git a/third_party/WebKit/Source/core/animation/animatable/AnimatableValueKeyframe.h b/third_party/WebKit/Source/core/animation/animatable/AnimatableValueKeyframe.h
+index bb3f5ea9506ae4a34be55e72effc1eb31a90c660..fb7d216e8c2446534a88598b8f61360cf1fd7063 100644
+--- a/third_party/WebKit/Source/core/animation/animatable/AnimatableValueKeyframe.h
++++ b/third_party/WebKit/Source/core/animation/animatable/AnimatableValueKeyframe.h
+@@ -38,7 +38,7 @@ public:
+         }
+ 
+         AnimatableValue* value() const { return m_value.get(); }
+-        const PassRefPtr<AnimatableValue> getAnimatableValue() const final { return m_value; }
++        PassRefPtr<AnimatableValue> getAnimatableValue() const final { return m_value; }
+ 
+         PassRefPtr<Keyframe::PropertySpecificKeyframe> neutralKeyframe(double offset, PassRefPtr<TimingFunction> easing) const final;
+         PassRefPtr<Interpolation> createInterpolation(PropertyHandle, const Keyframe::PropertySpecificKeyframe& end) const final;
+diff --git a/third_party/WebKit/Source/core/css/CSSFontFaceSourceTest.cpp b/third_party/WebKit/Source/core/css/CSSFontFaceSourceTest.cpp
+index 4a66edeac4d9cb73e3837c8a9fe66e4194ef4987..629c39602568bb70eb7cb11519c32ef17b278f0c 100644
+--- a/third_party/WebKit/Source/core/css/CSSFontFaceSourceTest.cpp
++++ b/third_party/WebKit/Source/core/css/CSSFontFaceSourceTest.cpp
+@@ -17,7 +17,7 @@ class DummyFontFaceSource : public CSSFontFaceSource {
+ public:
+     PassRefPtr<SimpleFontData> createFontData(const FontDescription&) override
+     {
+-        return SimpleFontData::create(FontPlatformData(fromSkSp(SkTypeface::MakeDefault()), "", 0, false, false));
++        return SimpleFontData::create(FontPlatformData(SkTypeface::MakeDefault(), "", 0, false, false));
+     }
+ 
+     DummyFontFaceSource() { }
 diff --git a/third_party/WebKit/Source/core/dom/DOMArrayBuffer.h b/third_party/WebKit/Source/core/dom/DOMArrayBuffer.h
 index e436a079e835ad465a5262249f0a402d58e25f02..872df7f2c47de00abc32a95f7564172090b75527 100644
 --- a/third_party/WebKit/Source/core/dom/DOMArrayBuffer.h
@@ -2349,6 +2644,1493 @@ index 82775974231274e6639751139f5c7bc9bbfaad25..8aca09939d20cc48cfa85c507fdea17c
      readonly attribute long long lastModified;
  
      // Non-standard APIs
+diff --git a/third_party/WebKit/Source/core/frame/ImageBitmap.cpp b/third_party/WebKit/Source/core/frame/ImageBitmap.cpp
+index 86600c029a2e977cc5a5404e250adb764c7fb184..c7841d522be803cf7f646b0d0c680b1d1de4d511 100644
+--- a/third_party/WebKit/Source/core/frame/ImageBitmap.cpp
++++ b/third_party/WebKit/Source/core/frame/ImageBitmap.cpp
+@@ -45,12 +45,6 @@ static inline IntRect normalizeRect(const IntRect& rect)
+         std::max(rect.height(), -rect.height()));
+ }
+ 
+-static bool frameIsValid(const SkBitmap& frameBitmap)
+-{
+-    ASSERT(!frameBitmap.isNull() && !frameBitmap.empty() && frameBitmap.isImmutable());
+-    return frameBitmap.colorType() == kN32_SkColorType;
+-}
+-
+ ParsedOptions parseOptions(const ImageBitmapOptions& options, Optional<IntRect> cropRect, IntSize sourceSize)
+ {
+     ParsedOptions parsedOptions;
+@@ -139,13 +133,13 @@ static PassRefPtr<Uint8Array> copySkImageData(SkImage* input, const SkImageInfo&
+     return dstPixels;
+ }
+ 
+-static PassRefPtr<SkImage> newSkImageFromRaster(const SkImageInfo& info, PassRefPtr<Uint8Array> imagePixels, size_t imageRowBytes)
++static sk_sp<SkImage> newSkImageFromRaster(const SkImageInfo& info, PassRefPtr<Uint8Array> imagePixels, size_t imageRowBytes)
+ {
+     SkPixmap pixmap(info, imagePixels->data(), imageRowBytes);
+-    return fromSkSp(SkImage::MakeFromRaster(pixmap, [](const void*, void* pixels)
++    return SkImage::MakeFromRaster(pixmap, [](const void*, void* pixels)
+         {
+             static_cast<Uint8Array*>(pixels)->deref();
+-        }, imagePixels.leakRef()));
++        }, imagePixels.leakRef());
+ }
+ 
+ static void swizzleImageData(unsigned char* srcAddr, size_t height, size_t bytesPerRow, bool flipY)
+@@ -172,7 +166,7 @@ static void swizzleImageData(unsigned char* srcAddr, size_t height, size_t bytes
+     }
+ }
+ 
+-static PassRefPtr<SkImage> flipSkImageVertically(SkImage* input, AlphaDisposition alphaOp)
++static sk_sp<SkImage> flipSkImageVertically(SkImage* input, AlphaDisposition alphaOp)
+ {
+     size_t width = static_cast<size_t>(input->width());
+     size_t height = static_cast<size_t>(input->height());
+@@ -190,7 +184,7 @@ static PassRefPtr<SkImage> flipSkImageVertically(SkImage* input, AlphaDispositio
+     return newSkImageFromRaster(info, std::move(imagePixels), imageRowBytes);
+ }
+ 
+-static PassRefPtr<SkImage> premulSkImageToUnPremul(SkImage* input)
++static sk_sp<SkImage> premulSkImageToUnPremul(SkImage* input)
+ {
+     SkImageInfo info = SkImageInfo::Make(input->width(), input->height(), kN32_SkColorType, kUnpremul_SkAlphaType);
+     RefPtr<Uint8Array> dstPixels = copySkImageData(input, info);
+@@ -199,7 +193,7 @@ static PassRefPtr<SkImage> premulSkImageToUnPremul(SkImage* input)
+     return newSkImageFromRaster(info, std::move(dstPixels), static_cast<size_t>(input->width()) * info.bytesPerPixel());
+ }
+ 
+-static PassRefPtr<SkImage> unPremulSkImageToPremul(SkImage* input)
++static sk_sp<SkImage> unPremulSkImageToPremul(SkImage* input)
+ {
+     SkImageInfo info = SkImageInfo::Make(input->width(), input->height(), kN32_SkColorType, kPremul_SkAlphaType);
+     RefPtr<Uint8Array> dstPixels = copySkImageData(input, info);
+@@ -208,17 +202,15 @@ static PassRefPtr<SkImage> unPremulSkImageToPremul(SkImage* input)
+     return newSkImageFromRaster(info, std::move(dstPixels), static_cast<size_t>(input->width()) * info.bytesPerPixel());
+ }
+ 
+-PassRefPtr<SkImage> ImageBitmap::getSkImageFromDecoder(std::unique_ptr<ImageDecoder> decoder)
++sk_sp<SkImage> ImageBitmap::getSkImageFromDecoder(std::unique_ptr<ImageDecoder> decoder)
+ {
+     if (!decoder->frameCount())
+         return nullptr;
+     ImageFrame* frame = decoder->frameBufferAtIndex(0);
+     if (!frame || frame->getStatus() != ImageFrame::FrameComplete)
+         return nullptr;
+-    SkBitmap bitmap = frame->bitmap();
+-    if (!frameIsValid(bitmap))
+-        return nullptr;
+-    return fromSkSp(SkImage::MakeFromBitmap(bitmap));
++    DCHECK(!frame->bitmap().isNull() && !frame->bitmap().empty());
++    return frame->finalizePixelsAndGetImage();
+ }
+ 
+ bool ImageBitmap::isResizeOptionValid(const ImageBitmapOptions& options, ExceptionState& exceptionState)
+@@ -260,7 +252,7 @@ static PassRefPtr<StaticBitmapImage> cropImage(Image* image, const ParsedOptions
+         return StaticBitmapImage::create(newSkImageFromRaster(info, std::move(dstPixels), static_cast<size_t>(info.width()) * info.bytesPerPixel()));
+     }
+ 
+-    RefPtr<SkImage> skiaImage = image->imageForCurrentFrame();
++    sk_sp<SkImage> skiaImage = image->imageForCurrentFrame();
+     // Attempt to get raw unpremultiplied image data, executed only when skiaImage is premultiplied.
+     if ((((!parsedOptions.premultiplyAlpha && !skiaImage->isOpaque()) || !skiaImage) && image->data() && imageFormat == PremultiplyAlpha) || colorSpaceOp == ImageDecoder::GammaAndColorProfileIgnored) {
+         std::unique_ptr<ImageDecoder> decoder(ImageDecoder::create(
+@@ -275,7 +267,7 @@ static PassRefPtr<StaticBitmapImage> cropImage(Image* image, const ParsedOptions
+     }
+ 
+     if (parsedOptions.cropRect == srcRect && !parsedOptions.shouldScaleInput) {
+-        RefPtr<SkImage> croppedSkImage = fromSkSp(skiaImage->makeSubset(srcRect));
++        sk_sp<SkImage> croppedSkImage = skiaImage->makeSubset(srcRect);
+         if (parsedOptions.flipY)
+             return StaticBitmapImage::create(flipSkImageVertically(croppedSkImage.get(), parsedOptions.premultiplyAlpha ? PremultiplyAlpha : DontPremultiplyAlpha));
+         // Special case: The first parameter image is unpremul but we need to turn it into premul.
+@@ -283,14 +275,14 @@ static PassRefPtr<StaticBitmapImage> cropImage(Image* image, const ParsedOptions
+             return StaticBitmapImage::create(unPremulSkImageToPremul(croppedSkImage.get()));
+         // Call preroll to trigger image decoding.
+         croppedSkImage->preroll();
+-        return StaticBitmapImage::create(croppedSkImage.release());
++        return StaticBitmapImage::create(std::move(croppedSkImage));
+     }
+ 
+     sk_sp<SkSurface> surface = SkSurface::MakeRasterN32Premul(parsedOptions.resizeWidth, parsedOptions.resizeHeight);
+     if (!surface)
+         return nullptr;
+     if (srcRect.isEmpty())
+-        return StaticBitmapImage::create(fromSkSp(surface->makeImageSnapshot()));
++        return StaticBitmapImage::create(surface->makeImageSnapshot());
+ 
+     SkScalar dstLeft = std::min(0, -parsedOptions.cropRect.x());
+     SkScalar dstTop = std::min(0, -parsedOptions.cropRect.y());
+@@ -307,16 +299,16 @@ static PassRefPtr<StaticBitmapImage> cropImage(Image* image, const ParsedOptions
+         SkRect drawDstRect = SkRect::MakeXYWH(0, 0, parsedOptions.resizeWidth, parsedOptions.resizeHeight);
+         SkPaint paint;
+         paint.setFilterQuality(parsedOptions.resizeQuality);
+-        surface->getCanvas()->drawImageRect(skiaImage.get(), drawSrcRect, drawDstRect, &paint);
++        surface->getCanvas()->drawImageRect(skiaImage, drawSrcRect, drawDstRect, &paint);
+     } else {
+-        surface->getCanvas()->drawImage(skiaImage.get(), dstLeft, dstTop);
++        surface->getCanvas()->drawImage(skiaImage, dstLeft, dstTop);
+     }
+-    skiaImage = fromSkSp(surface->makeImageSnapshot());
++    skiaImage = surface->makeImageSnapshot();
+ 
+     if (parsedOptions.premultiplyAlpha) {
+         if (imageFormat == DontPremultiplyAlpha)
+             return StaticBitmapImage::create(unPremulSkImageToPremul(skiaImage.get()));
+-        return StaticBitmapImage::create(skiaImage.release());
++        return StaticBitmapImage::create(std::move(skiaImage));
+     }
+     return StaticBitmapImage::create(premulSkImageToUnPremul(skiaImage.get()));
+ }
+@@ -336,12 +328,12 @@ ImageBitmap::ImageBitmap(HTMLImageElement* image, Optional<IntRect> cropRect, Do
+         return;
+     // In the case where the source image is lazy-decoded, m_image may not be in
+     // a decoded state, we trigger it here.
+-    RefPtr<SkImage> skImage = m_image->imageForCurrentFrame();
++    sk_sp<SkImage> skImage = m_image->imageForCurrentFrame();
+     SkPixmap pixmap;
+     if (!skImage->isTextureBacked() && !skImage->peekPixels(&pixmap)) {
+         sk_sp<SkSurface> surface = SkSurface::MakeRasterN32Premul(skImage->width(), skImage->height());
+-        surface->getCanvas()->drawImage(skImage.get(), 0, 0);
+-        m_image = StaticBitmapImage::create(fromSkSp(surface->makeImageSnapshot()));
++        surface->getCanvas()->drawImage(skImage, 0, 0);
++        m_image = StaticBitmapImage::create(surface->makeImageSnapshot());
+     }
+     if (!m_image)
+         return;
+@@ -380,12 +372,12 @@ ImageBitmap::ImageBitmap(HTMLVideoElement* video, Optional<IntRect> cropRect, Do
+     }
+     video->paintCurrentFrame(buffer->canvas(), IntRect(dstPoint, dstSize), parsedOptions.shouldScaleInput ? &paint : nullptr);
+ 
+-    RefPtr<SkImage> skiaImage = buffer->newSkImageSnapshot(PreferNoAcceleration, SnapshotReasonUnknown);
++    sk_sp<SkImage> skiaImage = buffer->newSkImageSnapshot(PreferNoAcceleration, SnapshotReasonUnknown);
+     if (!parsedOptions.premultiplyAlpha)
+         skiaImage = premulSkImageToUnPremul(skiaImage.get());
+     if (!skiaImage)
+         return;
+-    m_image = StaticBitmapImage::create(skiaImage.release());
++    m_image = StaticBitmapImage::create(std::move(skiaImage));
+     m_image->setOriginClean(!video->wouldTaintOrigin(document->getSecurityOrigin()));
+     m_image->setPremultiplied(parsedOptions.premultiplyAlpha);
+ }
+@@ -419,14 +411,14 @@ ImageBitmap::ImageBitmap(HTMLCanvasElement* canvas, Optional<IntRect> cropRect,
+ ImageBitmap::ImageBitmap(std::unique_ptr<uint8_t[]> data, uint32_t width, uint32_t height, bool isImageBitmapPremultiplied, bool isImageBitmapOriginClean)
+ {
+     SkImageInfo info = SkImageInfo::MakeN32(width, height, isImageBitmapPremultiplied ? kPremul_SkAlphaType : kUnpremul_SkAlphaType);
+-    m_image = StaticBitmapImage::create(fromSkSp(SkImage::MakeRasterCopy(SkPixmap(info, data.get(), info.bytesPerPixel() * width))));
++    m_image = StaticBitmapImage::create(SkImage::MakeRasterCopy(SkPixmap(info, data.get(), info.bytesPerPixel() * width)));
+     if (!m_image)
+         return;
+     m_image->setPremultiplied(isImageBitmapPremultiplied);
+     m_image->setOriginClean(isImageBitmapOriginClean);
+ }
+ 
+-static PassRefPtr<SkImage> scaleSkImage(PassRefPtr<SkImage> skImage, unsigned resizeWidth, unsigned resizeHeight, SkFilterQuality resizeQuality)
++static sk_sp<SkImage> scaleSkImage(sk_sp<SkImage> skImage, unsigned resizeWidth, unsigned resizeHeight, SkFilterQuality resizeQuality)
+ {
+     SkImageInfo resizedInfo = SkImageInfo::Make(resizeWidth, resizeHeight, kN32_SkColorType, kUnpremul_SkAlphaType);
+     RefPtr<ArrayBuffer> dstBuffer = ArrayBuffer::createOrNull(resizeWidth * resizeHeight, resizedInfo.bytesPerPixel());
+@@ -435,10 +427,10 @@ static PassRefPtr<SkImage> scaleSkImage(PassRefPtr<SkImage> skImage, unsigned re
+     RefPtr<Uint8Array> resizedPixels = Uint8Array::create(dstBuffer, 0, dstBuffer->byteLength());
+     SkPixmap pixmap(resizedInfo, resizedPixels->data(), static_cast<size_t>(resizeWidth) * resizedInfo.bytesPerPixel());
+     skImage->scalePixels(pixmap, resizeQuality);
+-    return fromSkSp(SkImage::MakeFromRaster(pixmap, [](const void*, void* pixels)
++    return SkImage::MakeFromRaster(pixmap, [](const void*, void* pixels)
+         {
+             static_cast<Uint8Array*>(pixels)->deref();
+-        }, resizedPixels.release().leakRef()));
++        }, resizedPixels.release().leakRef());
+ }
+ 
+ ImageBitmap::ImageBitmap(ImageData* data, Optional<IntRect> cropRect, const ImageBitmapOptions& options)
+@@ -459,10 +451,10 @@ ImageBitmap::ImageBitmap(ImageData* data, Optional<IntRect> cropRect, const Imag
+         size_t bytesPerPixel = static_cast<size_t>(info.bytesPerPixel());
+         size_t srcPixelBytesPerRow = bytesPerPixel * data->size().width();
+         size_t dstPixelBytesPerRow = bytesPerPixel * parsedOptions.cropRect.width();
+-        RefPtr<SkImage> skImage;
++        sk_sp<SkImage> skImage;
+         if (parsedOptions.cropRect == IntRect(IntPoint(), data->size())) {
+             swizzleImageData(srcAddr, data->size().height(), srcPixelBytesPerRow, parsedOptions.flipY);
+-            skImage = fromSkSp(SkImage::MakeRasterCopy(SkPixmap(info, srcAddr, dstPixelBytesPerRow)));
++            skImage = SkImage::MakeRasterCopy(SkPixmap(info, srcAddr, dstPixelBytesPerRow));
+             // restore the original ImageData
+             swizzleImageData(srcAddr, data->size().height(), srcPixelBytesPerRow, parsedOptions.flipY);
+         } else {
+@@ -531,7 +523,7 @@ ImageBitmap::ImageBitmap(ImageData* data, Optional<IntRect> cropRect, const Imag
+     if (parsedOptions.cropRect.y() < 0)
+         dstPoint.setY(-parsedOptions.cropRect.y());
+     buffer->putByteArray(Unmultiplied, data->data()->data(), data->size(), srcRect, dstPoint);
+-    RefPtr<SkImage> skImage = buffer->newSkImageSnapshot(PreferNoAcceleration, SnapshotReasonUnknown);
++    sk_sp<SkImage> skImage = buffer->newSkImageSnapshot(PreferNoAcceleration, SnapshotReasonUnknown);
+     if (parsedOptions.flipY)
+         skImage = flipSkImageVertically(skImage.get(), PremultiplyAlpha);
+     if (!skImage)
+@@ -543,10 +535,10 @@ ImageBitmap::ImageBitmap(ImageData* data, Optional<IntRect> cropRect, const Imag
+         SkPaint paint;
+         paint.setFilterQuality(parsedOptions.resizeQuality);
+         SkRect dstDrawRect = SkRect::MakeWH(parsedOptions.resizeWidth, parsedOptions.resizeHeight);
+-        surface->getCanvas()->drawImageRect(skImage.get(), dstDrawRect, &paint);
+-        skImage = fromSkSp(surface->makeImageSnapshot());
++        surface->getCanvas()->drawImageRect(skImage, dstDrawRect, &paint);
++        skImage = surface->makeImageSnapshot();
+     }
+-    m_image = StaticBitmapImage::create(skImage);
++    m_image = StaticBitmapImage::create(std::move(skImage));
+ }
+ 
+ ImageBitmap::ImageBitmap(ImageBitmap* bitmap, Optional<IntRect> cropRect, const ImageBitmapOptions& options)
+@@ -648,7 +640,7 @@ void ImageBitmap::close()
+ // static
+ ImageBitmap* ImageBitmap::take(ScriptPromiseResolver*, sk_sp<SkImage> image)
+ {
+-    return ImageBitmap::create(StaticBitmapImage::create(fromSkSp(image)));
++    return ImageBitmap::create(StaticBitmapImage::create(std::move(image)));
+ }
+ 
+ PassRefPtr<Uint8Array> ImageBitmap::copyBitmapData(AlphaDisposition alphaOp, DataColorFormat format)
+diff --git a/third_party/WebKit/Source/core/frame/ImageBitmap.h b/third_party/WebKit/Source/core/frame/ImageBitmap.h
+index b6f2590d2c6fdd5f7714044d6b6fbf174237b32f..312a62d266634767796733741f49430ce3bb9cb1 100644
+--- a/third_party/WebKit/Source/core/frame/ImageBitmap.h
++++ b/third_party/WebKit/Source/core/frame/ImageBitmap.h
+@@ -16,6 +16,7 @@
+ #include "platform/graphics/ImageBuffer.h"
+ #include "platform/graphics/StaticBitmapImage.h"
+ #include "platform/heap/Handle.h"
++#include "third_party/skia/include/core/SkRefCnt.h"
+ #include "wtf/PassRefPtr.h"
+ #include <memory>
+ 
+@@ -48,7 +49,7 @@ public:
+     // isImageBitmapPremultiplied indicates whether the original ImageBitmap is premultiplied or not.
+     // isImageBitmapOriginClean indicates whether the original ImageBitmap is origin clean or not.
+     static ImageBitmap* create(std::unique_ptr<uint8_t[]> data, uint32_t width, uint32_t height, bool isImageBitmapPremultiplied, bool isImageBitmapOriginClean);
+-    static PassRefPtr<SkImage> getSkImageFromDecoder(std::unique_ptr<ImageDecoder>);
++    static sk_sp<SkImage> getSkImageFromDecoder(std::unique_ptr<ImageDecoder>);
+     static bool isResizeOptionValid(const ImageBitmapOptions&, ExceptionState&);
+     static bool isSourceSizeValid(int sourceWidth, int sourceHeight, ExceptionState&);
+ 
+diff --git a/third_party/WebKit/Source/core/frame/ImageBitmapTest.cpp b/third_party/WebKit/Source/core/frame/ImageBitmapTest.cpp
+index 6919c835615110439bccbdc5d81ed46fba7b08da..20ab0a3a7b04ba68289fd49b86cdd83ee3ee7b78 100644
+--- a/third_party/WebKit/Source/core/frame/ImageBitmapTest.cpp
++++ b/third_party/WebKit/Source/core/frame/ImageBitmapTest.cpp
+@@ -54,11 +54,11 @@ protected:
+     {
+         sk_sp<SkSurface> surface = SkSurface::MakeRasterN32Premul(10, 10);
+         surface->getCanvas()->clear(0xFFFFFFFF);
+-        m_image = fromSkSp(surface->makeImageSnapshot());
++        m_image = surface->makeImageSnapshot();
+ 
+         sk_sp<SkSurface> surface2 = SkSurface::MakeRasterN32Premul(5, 5);
+         surface2->getCanvas()->clear(0xAAAAAAAA);
+-        m_image2 = fromSkSp(surface2->makeImageSnapshot());
++        m_image2 = surface2->makeImageSnapshot();
+ 
+         // Save the global memory cache to restore it upon teardown.
+         m_globalMemoryCache = replaceMemoryCacheForTesting(MemoryCache::create());
+@@ -73,7 +73,7 @@ protected:
+         replaceMemoryCacheForTesting(m_globalMemoryCache.release());
+     }
+ 
+-    RefPtr<SkImage> m_image, m_image2;
++    sk_sp<SkImage> m_image, m_image2;
+     Persistent<MemoryCache> m_globalMemoryCache;
+ };
+ 
+diff --git a/third_party/WebKit/Source/core/frame/LocalFrame.cpp b/third_party/WebKit/Source/core/frame/LocalFrame.cpp
+index f74e510e3e503caffd2cb14f6bb1752c144fd041..db5f7365f75ec32873e58374fc6a8400365b30ef 100644
+--- a/third_party/WebKit/Source/core/frame/LocalFrame.cpp
++++ b/third_party/WebKit/Source/core/frame/LocalFrame.cpp
+@@ -129,10 +129,10 @@ public:
+     {
+         context().getPaintController().endItem<EndTransformDisplayItem>(*m_pictureBuilder);
+         // TODO(fmalita): endRecording() should return a non-const SKP.
+-        sk_sp<SkPicture> recording(const_cast<SkPicture*>(m_pictureBuilder->endRecording().leakRef()));
+-        RefPtr<SkImage> skImage = fromSkSp(SkImage::MakeFromPicture(std::move(recording),
+-            SkISize::Make(m_bounds.width(), m_bounds.height()), nullptr, nullptr));
+-        RefPtr<Image> image = StaticBitmapImage::create(skImage.release());
++        sk_sp<SkPicture> recording(const_cast<SkPicture*>(m_pictureBuilder->endRecording().release()));
++        sk_sp<SkImage> skImage = SkImage::MakeFromPicture(std::move(recording),
++            SkISize::Make(m_bounds.width(), m_bounds.height()), nullptr, nullptr);
++        RefPtr<Image> image = StaticBitmapImage::create(std::move(skImage));
+         float screenDeviceScaleFactor = m_localFrame->page()->chromeClient().screenInfo().deviceScaleFactor;
+ 
+         return DragImage::create(image.get(), imageOrientation, screenDeviceScaleFactor, InterpolationHigh, opacity);
+diff --git a/third_party/WebKit/Source/core/html/HTMLCanvasElement.cpp b/third_party/WebKit/Source/core/html/HTMLCanvasElement.cpp
+index 69b42e89c048849d338654ba0a906fa6fd2a63de..9ec0e15ee415e2d3c8463837151c3a6201bf026e 100644
+--- a/third_party/WebKit/Source/core/html/HTMLCanvasElement.cpp
++++ b/third_party/WebKit/Source/core/html/HTMLCanvasElement.cpp
+@@ -116,7 +116,7 @@ PassRefPtr<Image> createTransparentImage(const IntSize& size)
+ {
+     DCHECK(ImageBuffer::canCreateImageBuffer(size));
+     sk_sp<SkSurface> surface = SkSurface::MakeRasterN32Premul(size.width(), size.height());
+-    return StaticBitmapImage::create(fromSkSp(surface->makeImageSnapshot()));
++    return StaticBitmapImage::create(surface->makeImageSnapshot());
+ }
+ 
+ } // namespace
+@@ -255,11 +255,7 @@ bool HTMLCanvasElement::shouldBeDirectComposited() const
+ 
+ bool HTMLCanvasElement::isPaintable() const
+ {
+-    if (!m_context)
+-        return ImageBuffer::canCreateImageBuffer(size());
+-    if (m_context->getContextType() == CanvasRenderingContext::ContextImageBitmap)
+-        return (renderingContext()->getImage().get());
+-    return buffer();
++    return (m_context && m_context->isPaintable()) || ImageBuffer::canCreateImageBuffer(size());
+ }
+ 
+ void HTMLCanvasElement::didDraw(const FloatRect& rect)
+@@ -458,7 +454,7 @@ void HTMLCanvasElement::notifyListenersCanvasChanged()
+         RefPtr<Image> sourceImage = getSourceImageForCanvas(&status, PreferNoAcceleration, SnapshotReasonCanvasListenerCapture, FloatSize());
+         if (status != NormalSourceImageStatus)
+             return;
+-        RefPtr<SkImage> image = sourceImage->imageForCurrentFrame();
++        sk_sp<SkImage> image = sourceImage->imageForCurrentFrame();
+         for (CanvasDrawListener* listener : m_listeners) {
+             if (listener->needsNewFrame()) {
+                 listener->sendNewFrame(image);
+@@ -607,7 +603,7 @@ ImageData* HTMLCanvasElement::toImageData(SourceDrawingBuffer sourceBuffer, Snap
+ 
+         m_context->paintRenderingResultsToCanvas(sourceBuffer);
+         imageData = ImageData::create(m_size);
+-        RefPtr<SkImage> snapshot = buffer()->newSkImageSnapshot(PreferNoAcceleration, reason);
++        sk_sp<SkImage> snapshot = buffer()->newSkImageSnapshot(PreferNoAcceleration, reason);
+         if (snapshot) {
+             SkImageInfo imageInfo = SkImageInfo::Make(width(), height(), kRGBA_8888_SkColorType, kUnpremul_SkAlphaType);
+             snapshot->readPixels(imageInfo, imageData->data()->data(), imageInfo.minRowBytes(), 0, 0);
+@@ -621,7 +617,7 @@ ImageData* HTMLCanvasElement::toImageData(SourceDrawingBuffer sourceBuffer, Snap
+         return imageData;
+ 
+     DCHECK(m_context->is2d());
+-    RefPtr<SkImage> snapshot = buffer()->newSkImageSnapshot(PreferNoAcceleration, reason);
++    sk_sp<SkImage> snapshot = buffer()->newSkImageSnapshot(PreferNoAcceleration, reason);
+     if (snapshot) {
+         SkImageInfo imageInfo = SkImageInfo::Make(width(), height(), kRGBA_8888_SkColorType, kUnpremul_SkAlphaType);
+         snapshot->readPixels(imageInfo, imageData->data()->data(), imageInfo.minRowBytes(), 0, 0);
+@@ -1134,17 +1130,15 @@ PassRefPtr<Image> HTMLCanvasElement::getSourceImageForCanvas(SourceImageStatus*
+         m_context->paintRenderingResultsToCanvas(BackBuffer);
+     }
+ 
+-    RefPtr<SkImage> skImage;
+-    RefPtr<blink::Image> image = renderingContext()->getImage();
++    sk_sp<SkImage> skImage;
++    RefPtr<blink::Image> image = renderingContext()->getImage(reason);
+ 
+     if (image)
+         skImage = image->imageForCurrentFrame();
+-    else
+-        skImage = hasImageBuffer() ? buffer()->newSkImageSnapshot(hint, reason) : createTransparentImage(size())->imageForCurrentFrame();
+ 
+     if (skImage) {
+         *status = NormalSourceImageStatus;
+-        return StaticBitmapImage::create(skImage.release());
++        return StaticBitmapImage::create(std::move(skImage));
+     }
+ 
+     *status = InvalidSourceImageStatus;
+diff --git a/third_party/WebKit/Source/core/html/canvas/CanvasDrawListener.cpp b/third_party/WebKit/Source/core/html/canvas/CanvasDrawListener.cpp
+index 0fa892a557788429d1eb496688fc4ee50b5296fd..78f922616c09a59dbd8d640606d8add2e7dd87b2 100644
+--- a/third_party/WebKit/Source/core/html/canvas/CanvasDrawListener.cpp
++++ b/third_party/WebKit/Source/core/html/canvas/CanvasDrawListener.cpp
+@@ -4,13 +4,14 @@
+ 
+ #include "core/html/canvas/CanvasDrawListener.h"
+ 
++#include "third_party/skia/include/core/SkImage.h"
+ #include <memory>
+ 
+ namespace blink {
+ 
+ CanvasDrawListener::~CanvasDrawListener() {}
+ 
+-void CanvasDrawListener::sendNewFrame(const WTF::PassRefPtr<SkImage>& image)
++void CanvasDrawListener::sendNewFrame(sk_sp<SkImage> image)
+ {
+     m_handler->sendNewFrame(image.get());
+ }
+diff --git a/third_party/WebKit/Source/core/html/canvas/CanvasDrawListener.h b/third_party/WebKit/Source/core/html/canvas/CanvasDrawListener.h
+index e0a654dbbe1491f475f5a180fe7ed6f9ab780552..04589d4eab41694cee31fe632ea0fa63ec0877cb 100644
+--- a/third_party/WebKit/Source/core/html/canvas/CanvasDrawListener.h
++++ b/third_party/WebKit/Source/core/html/canvas/CanvasDrawListener.h
+@@ -8,7 +8,7 @@
+ #include "core/CoreExport.h"
+ #include "platform/heap/Handle.h"
+ #include "public/platform/WebCanvasCaptureHandler.h"
+-#include "wtf/PassRefPtr.h"
++#include "third_party/skia/include/core/SkRefCnt.h"
+ #include <memory>
+ 
+ class SkImage;
+@@ -18,7 +18,7 @@ namespace blink {
+ class CORE_EXPORT CanvasDrawListener : public GarbageCollectedMixin {
+ public:
+     virtual ~CanvasDrawListener();
+-    virtual void sendNewFrame(const WTF::PassRefPtr<SkImage>&);
++    virtual void sendNewFrame(sk_sp<SkImage>);
+     bool needsNewFrame() const;
+     void requestFrame();
+ 
+diff --git a/third_party/WebKit/Source/core/html/canvas/CanvasImageSource.h b/third_party/WebKit/Source/core/html/canvas/CanvasImageSource.h
+index 8713294679e6cd202e547f990c75160e8a79d29c..f38c8e22c88062cad45ce419336adf2364cbff3b 100644
+--- a/third_party/WebKit/Source/core/html/canvas/CanvasImageSource.h
++++ b/third_party/WebKit/Source/core/html/canvas/CanvasImageSource.h
+@@ -58,6 +58,7 @@ public:
+     virtual bool isCanvasElement() const { return false; }
+     virtual bool isSVGSource() const { return false; }
+     virtual bool isImageBitmap() const { return false; }
++    virtual bool isOffscreenCanvas() const { return false; }
+ 
+     // Adjusts the source and destination rectangles for cases where the actual
+     // source image is a subregion of the image returned by getSourceImageForCanvas.
+diff --git a/third_party/WebKit/Source/core/html/canvas/CanvasRenderingContext.h b/third_party/WebKit/Source/core/html/canvas/CanvasRenderingContext.h
+index ae6df2e2c766902e98be7b79233c49dfe2830676..72446e5325951888570882b4d3d75c172b9b0287 100644
+--- a/third_party/WebKit/Source/core/html/canvas/CanvasRenderingContext.h
++++ b/third_party/WebKit/Source/core/html/canvas/CanvasRenderingContext.h
+@@ -81,6 +81,7 @@ public:
+     WTF::String colorSpaceAsString() const;
+     sk_sp<SkColorSpace> skColorSpace() const;
+ 
++    virtual PassRefPtr<Image> getImage(SnapshotReason) const = 0;
+     virtual ContextType getContextType() const = 0;
+     virtual bool isAccelerated() const { return false; }
+     virtual bool shouldAntialias() const { return false; }
+@@ -88,12 +89,11 @@ public:
+     virtual bool isContextLost() const { return true; }
+     virtual void setCanvasGetContextResult(RenderingContext&) { NOTREACHED(); };
+     virtual void setOffscreenCanvasGetContextResult(OffscreenRenderingContext&) { NOTREACHED(); }
++    virtual bool isPaintable() const = 0;
+ 
+     // Return true if the content is updated.
+     virtual bool paintRenderingResultsToCanvas(SourceDrawingBuffer) { return false; }
+ 
+-    // Note: this function is strictly for OffscreenCanvas only.
+-    virtual bool isPaintable() const = 0;
+ 
+     virtual WebLayer* platformLayer() const { return nullptr; }
+ 
+@@ -137,15 +137,14 @@ public:
+ 
+     // ImageBitmap-specific interface
+     virtual bool paint(GraphicsContext&, const IntRect&) { return false; }
+-    virtual PassRefPtr<Image> getImage() const { return nullptr; }
+-
+-    bool wouldTaintOrigin(CanvasImageSource*, SecurityOrigin* = nullptr);
+-    void didMoveToNewDocument(Document*);
+ 
+     // OffscreenCanvas-specific methods
+     OffscreenCanvas* getOffscreenCanvas() const { return m_offscreenCanvas; }
+     virtual ImageBitmap* transferToImageBitmap(ExceptionState&) { return nullptr; }
+ 
++    bool wouldTaintOrigin(CanvasImageSource*, SecurityOrigin* = nullptr);
++    void didMoveToNewDocument(Document*);
++
+     void detachCanvas() { m_canvas = nullptr; }
+ 
+     const CanvasContextCreationAttributes& creationAttributes() const { return m_creationAttributes; }
+diff --git a/third_party/WebKit/Source/core/imagebitmap/ImageBitmapFactories.cpp b/third_party/WebKit/Source/core/imagebitmap/ImageBitmapFactories.cpp
+index 980a5ed33be70cd3b0e02f0f35a4b2a1bf3de9f7..34159762db287618d818fecc11e11872691b254c 100644
+--- a/third_party/WebKit/Source/core/imagebitmap/ImageBitmapFactories.cpp
++++ b/third_party/WebKit/Source/core/imagebitmap/ImageBitmapFactories.cpp
+@@ -233,14 +233,14 @@ void ImageBitmapFactories::ImageBitmapLoader::decodeImageOnDecoderThread(WebTask
+     if (colorSpaceConversionOption == "none")
+         colorSpaceOp = ImageDecoder::GammaAndColorProfileIgnored;
+     std::unique_ptr<ImageDecoder> decoder(ImageDecoder::create(sharedBuffer.release(), true, alphaOp, colorSpaceOp));
+-    RefPtr<SkImage> frame;
++    sk_sp<SkImage> frame;
+     if (decoder) {
+         frame = ImageBitmap::getSkImageFromDecoder(std::move(decoder));
+     }
+-    taskRunner->postTask(BLINK_FROM_HERE, crossThreadBind(&ImageBitmapFactories::ImageBitmapLoader::resolvePromiseOnOriginalThread, wrapCrossThreadPersistent(this), frame.release()));
++    taskRunner->postTask(BLINK_FROM_HERE, crossThreadBind(&ImageBitmapFactories::ImageBitmapLoader::resolvePromiseOnOriginalThread, wrapCrossThreadPersistent(this), std::move(frame)));
+ }
+ 
+-void ImageBitmapFactories::ImageBitmapLoader::resolvePromiseOnOriginalThread(PassRefPtr<SkImage> frame)
++void ImageBitmapFactories::ImageBitmapLoader::resolvePromiseOnOriginalThread(sk_sp<SkImage> frame)
+ {
+     if (!frame) {
+         rejectPromise();
+@@ -248,7 +248,7 @@ void ImageBitmapFactories::ImageBitmapLoader::resolvePromiseOnOriginalThread(Pas
+     }
+     ASSERT(frame->width() && frame->height());
+ 
+-    RefPtr<StaticBitmapImage> image = StaticBitmapImage::create(frame);
++    RefPtr<StaticBitmapImage> image = StaticBitmapImage::create(std::move(frame));
+     image->setOriginClean(true);
+     ImageBitmap* imageBitmap = ImageBitmap::create(image, m_cropRect, m_options);
+     if (imageBitmap && imageBitmap->bitmapImage()) {
+diff --git a/third_party/WebKit/Source/core/imagebitmap/ImageBitmapFactories.h b/third_party/WebKit/Source/core/imagebitmap/ImageBitmapFactories.h
+index 119e3dff83256062743011e0cadb7f7ea59aaf7d..9e2da85703f80ed8a88d52af8abc7937500d3043 100644
+--- a/third_party/WebKit/Source/core/imagebitmap/ImageBitmapFactories.h
++++ b/third_party/WebKit/Source/core/imagebitmap/ImageBitmapFactories.h
+@@ -40,6 +40,7 @@
+ #include "core/imagebitmap/ImageBitmapOptions.h"
+ #include "platform/Supplementable.h"
+ #include "platform/geometry/IntRect.h"
++#include "third_party/skia/include/core/SkRefCnt.h"
+ #include <memory>
+ 
+ class SkImage;
+@@ -94,7 +95,7 @@ private:
+ 
+         void scheduleAsyncImageBitmapDecoding(DOMArrayBuffer*);
+         void decodeImageOnDecoderThread(WebTaskRunner*, DOMArrayBuffer*, const String& premultiplyAlphaOption, const String& colorSpaceConversionOption);
+-        void resolvePromiseOnOriginalThread(PassRefPtr<SkImage>);
++        void resolvePromiseOnOriginalThread(sk_sp<SkImage>);
+ 
+         // FileReaderLoaderClient
+         void didStartLoading() override { }
+diff --git a/third_party/WebKit/Source/core/layout/ImageQualityControllerTest.cpp b/third_party/WebKit/Source/core/layout/ImageQualityControllerTest.cpp
+index 6ce9112bd97431f8f6fd132625e30f9fd810248b..e44b48bb08a47c7cf0592f3acb3a26a760987b70 100644
+--- a/third_party/WebKit/Source/core/layout/ImageQualityControllerTest.cpp
++++ b/third_party/WebKit/Source/core/layout/ImageQualityControllerTest.cpp
+@@ -56,7 +56,7 @@ public:
+     IntSize size() const override { return IntSize(); }
+     void destroyDecodedData() override { }
+     void draw(SkCanvas*, const SkPaint&, const FloatRect& dstRect, const FloatRect& srcRect, RespectImageOrientationEnum, ImageClampingMode) override { }
+-    PassRefPtr<SkImage> imageForCurrentFrame() override { return nullptr; }
++    sk_sp<SkImage> imageForCurrentFrame() override { return nullptr; }
+ };
+ 
+ TEST_F(ImageQualityControllerTest, ImageMaybeAnimated)
+@@ -77,7 +77,7 @@ public:
+     void draw(SkCanvas*, const SkPaint&, const FloatRect& dstRect, const FloatRect& srcRect, RespectImageOrientationEnum, ImageClampingMode) override { }
+ 
+     bool isBitmapImage() const override { return true; }
+-    PassRefPtr<SkImage> imageForCurrentFrame() override { return nullptr; }
++    sk_sp<SkImage> imageForCurrentFrame() override { return nullptr; }
+ };
+ 
+ TEST_F(ImageQualityControllerTest, LowQualityFilterForContrast)
+@@ -98,7 +98,7 @@ public:
+     void draw(SkCanvas*, const SkPaint&, const FloatRect& dstRect, const FloatRect& srcRect, RespectImageOrientationEnum, ImageClampingMode) override { }
+ 
+     bool isBitmapImage() const override { return true; }
+-    PassRefPtr<SkImage> imageForCurrentFrame() override { return nullptr; }
++    sk_sp<SkImage> imageForCurrentFrame() override { return nullptr; }
+ };
+ 
+ TEST_F(ImageQualityControllerTest, MediumQualityFilterForUnscaledImage)
+diff --git a/third_party/WebKit/Source/core/layout/svg/LayoutSVGResourceClipper.cpp b/third_party/WebKit/Source/core/layout/svg/LayoutSVGResourceClipper.cpp
+index 7a74cd77b9b53809b7c27d04914bf85e81cbe8c4..3ab5556ec6efbbb4c4122ae25e96ae48bf6186f8 100644
+--- a/third_party/WebKit/Source/core/layout/svg/LayoutSVGResourceClipper.cpp
++++ b/third_party/WebKit/Source/core/layout/svg/LayoutSVGResourceClipper.cpp
+@@ -49,7 +49,7 @@ LayoutSVGResourceClipper::~LayoutSVGResourceClipper()
+ void LayoutSVGResourceClipper::removeAllClientsFromCache(bool markForInvalidation)
+ {
+     m_clipContentPath.clear();
+-    m_clipContentPicture.clear();
++    m_clipContentPicture.reset();
+     m_localClipBounds = FloatRect();
+     markAllClientsForInvalidation(markForInvalidation ? LayoutAndBoundariesInvalidation : ParentOnlyInvalidation);
+ }
+@@ -158,7 +158,7 @@ bool LayoutSVGResourceClipper::asPath(const AffineTransform& animatedLocalTransf
+     return true;
+ }
+ 
+-PassRefPtr<const SkPicture> LayoutSVGResourceClipper::createContentPicture()
++sk_sp<const SkPicture> LayoutSVGResourceClipper::createContentPicture()
+ {
+     ASSERT(frame());
+     if (m_clipContentPicture)
+diff --git a/third_party/WebKit/Source/core/layout/svg/LayoutSVGResourceClipper.h b/third_party/WebKit/Source/core/layout/svg/LayoutSVGResourceClipper.h
+index 4a90d17eff50f686d315cc1bc16ed3f61d143841..1ebc65b064b47ef550b87b8f7b384a91065e7a08 100644
+--- a/third_party/WebKit/Source/core/layout/svg/LayoutSVGResourceClipper.h
++++ b/third_party/WebKit/Source/core/layout/svg/LayoutSVGResourceClipper.h
+@@ -22,6 +22,7 @@
+ 
+ #include "core/layout/svg/LayoutSVGResourceContainer.h"
+ #include "core/svg/SVGClipPathElement.h"
++#include "third_party/skia/include/core/SkRefCnt.h"
+ 
+ class SkPicture;
+ 
+@@ -47,7 +48,7 @@ public:
+     SVGUnitTypes::SVGUnitType clipPathUnits() const { return toSVGClipPathElement(element())->clipPathUnits()->currentValue()->enumValue(); }
+ 
+     bool asPath(const AffineTransform&, const FloatRect& referenceBox, Path&);
+-    PassRefPtr<const SkPicture> createContentPicture();
++    sk_sp<const SkPicture> createContentPicture();
+ 
+     bool hasCycle() { return m_inClipExpansion; }
+     void beginClipExpansion() { ASSERT(!m_inClipExpansion); m_inClipExpansion = true; }
+@@ -62,7 +63,7 @@ private:
+     Path m_clipContentPath;
+ 
+     // Cache of the clip path picture when falling back to masking for clipping.
+-    RefPtr<const SkPicture> m_clipContentPicture;
++    sk_sp<const SkPicture> m_clipContentPicture;
+ 
+     FloatRect m_localClipBounds;
+ 
+diff --git a/third_party/WebKit/Source/core/layout/svg/LayoutSVGResourceMasker.cpp b/third_party/WebKit/Source/core/layout/svg/LayoutSVGResourceMasker.cpp
+index 3355c67b8d54ea7e6f8f419948a7e1d2ec86f4cb..563591c7ed6ab3c377c0b381711440768132951e 100644
+--- a/third_party/WebKit/Source/core/layout/svg/LayoutSVGResourceMasker.cpp
++++ b/third_party/WebKit/Source/core/layout/svg/LayoutSVGResourceMasker.cpp
+@@ -40,7 +40,7 @@ LayoutSVGResourceMasker::~LayoutSVGResourceMasker()
+ 
+ void LayoutSVGResourceMasker::removeAllClientsFromCache(bool markForInvalidation)
+ {
+-    m_maskContentPicture.clear();
++    m_maskContentPicture.reset();
+     m_maskContentBoundaries = FloatRect();
+     markAllClientsForInvalidation(markForInvalidation ? LayoutAndBoundariesInvalidation : ParentOnlyInvalidation);
+ }
+@@ -51,7 +51,7 @@ void LayoutSVGResourceMasker::removeClientFromCache(LayoutObject* client, bool m
+     markClientForInvalidation(client, markForInvalidation ? BoundariesInvalidation : ParentOnlyInvalidation);
+ }
+ 
+-PassRefPtr<const SkPicture> LayoutSVGResourceMasker::createContentPicture(AffineTransform& contentTransformation, const FloatRect& targetBoundingBox,
++sk_sp<const SkPicture> LayoutSVGResourceMasker::createContentPicture(AffineTransform& contentTransformation, const FloatRect& targetBoundingBox,
+     GraphicsContext& context)
+ {
+     SVGUnitTypes::SVGUnitType contentUnits = toSVGMaskElement(element())->maskContentUnits()->currentValue()->enumValue();
+diff --git a/third_party/WebKit/Source/core/layout/svg/LayoutSVGResourceMasker.h b/third_party/WebKit/Source/core/layout/svg/LayoutSVGResourceMasker.h
+index bbc5e9ed13adb9450ea3bf008a30116115415f6a..3229bf66a129550a668ecdc1e0f8164bac598e6c 100644
+--- a/third_party/WebKit/Source/core/layout/svg/LayoutSVGResourceMasker.h
++++ b/third_party/WebKit/Source/core/layout/svg/LayoutSVGResourceMasker.h
+@@ -24,6 +24,7 @@
+ #include "core/svg/SVGMaskElement.h"
+ #include "core/svg/SVGUnitTypes.h"
+ #include "platform/geometry/FloatRect.h"
++#include "third_party/skia/include/core/SkRefCnt.h"
+ 
+ class SkPicture;
+ 
+@@ -50,12 +51,12 @@ public:
+     static const LayoutSVGResourceType s_resourceType = MaskerResourceType;
+     LayoutSVGResourceType resourceType() const override { return s_resourceType; }
+ 
+-    PassRefPtr<const SkPicture> createContentPicture(AffineTransform&, const FloatRect&, GraphicsContext&);
++    sk_sp<const SkPicture> createContentPicture(AffineTransform&, const FloatRect&, GraphicsContext&);
+ 
+ private:
+     void calculateMaskContentPaintInvalidationRect();
+ 
+-    RefPtr<const SkPicture> m_maskContentPicture;
++    sk_sp<const SkPicture> m_maskContentPicture;
+     FloatRect m_maskContentBoundaries;
+ };
+ 
+diff --git a/third_party/WebKit/Source/core/layout/svg/LayoutSVGResourcePattern.cpp b/third_party/WebKit/Source/core/layout/svg/LayoutSVGResourcePattern.cpp
+index f43d55a8522e69edf5f8ae1fd5bad554d20d2a50..422e81764975ead1c727686ee2d40e54a47bc4df 100644
+--- a/third_party/WebKit/Source/core/layout/svg/LayoutSVGResourcePattern.cpp
++++ b/third_party/WebKit/Source/core/layout/svg/LayoutSVGResourcePattern.cpp
+@@ -173,7 +173,7 @@ const LayoutSVGResourceContainer* LayoutSVGResourcePattern::resolveContentElemen
+     return this;
+ }
+ 
+-PassRefPtr<SkPicture> LayoutSVGResourcePattern::asPicture(const FloatRect& tileBounds,
++sk_sp<SkPicture> LayoutSVGResourcePattern::asPicture(const FloatRect& tileBounds,
+     const AffineTransform& tileTransform) const
+ {
+     ASSERT(!m_shouldCollectPatternAttributes);
+diff --git a/third_party/WebKit/Source/core/layout/svg/LayoutSVGResourcePattern.h b/third_party/WebKit/Source/core/layout/svg/LayoutSVGResourcePattern.h
+index 0c180980510f19e7b35ed3754d43c69bd8ec119a..1a82e770224ef64994e3bc803f8ff1745084b384 100644
+--- a/third_party/WebKit/Source/core/layout/svg/LayoutSVGResourcePattern.h
++++ b/third_party/WebKit/Source/core/layout/svg/LayoutSVGResourcePattern.h
+@@ -25,8 +25,8 @@
+ #include "core/layout/svg/LayoutSVGResourcePaintServer.h"
+ #include "core/svg/PatternAttributes.h"
+ #include "platform/heap/Handle.h"
++#include "third_party/skia/include/core/SkRefCnt.h"
+ #include "wtf/HashMap.h"
+-#include "wtf/RefPtr.h"
+ #include <memory>
+ 
+ class SkPicture;
+@@ -54,7 +54,7 @@ public:
+ 
+ private:
+     std::unique_ptr<PatternData> buildPatternData(const LayoutObject&);
+-    PassRefPtr<SkPicture> asPicture(const FloatRect& tile, const AffineTransform&) const;
++    sk_sp<SkPicture> asPicture(const FloatRect& tile, const AffineTransform&) const;
+     PatternData* patternForLayoutObject(const LayoutObject&);
+ 
+     const LayoutSVGResourceContainer* resolveContentElement() const;
+diff --git a/third_party/WebKit/Source/core/offscreencanvas/OffscreenCanvas.cpp b/third_party/WebKit/Source/core/offscreencanvas/OffscreenCanvas.cpp
+index 526b9fb656f544c1aa9ecb33fb014edb31cc774f..b5f8febd6e7bfcd7f93520e4634a53b70aa5fd7f 100644
+--- a/third_party/WebKit/Source/core/offscreencanvas/OffscreenCanvas.cpp
++++ b/third_party/WebKit/Source/core/offscreencanvas/OffscreenCanvas.cpp
+@@ -61,6 +61,23 @@ ImageBitmap* OffscreenCanvas::transferToImageBitmap(ExceptionState& exceptionSta
+     return image;
+ }
+ 
++PassRefPtr<Image> OffscreenCanvas::getSourceImageForCanvas(SourceImageStatus* status, AccelerationHint, SnapshotReason reason, const FloatSize&) const
++{
++    if (!m_context) {
++        *status = InvalidSourceImageStatus;
++        return nullptr;
++    }
++    *status = NormalSourceImageStatus;
++    return m_context->getImage(reason);
++}
++
++bool OffscreenCanvas::isOpaque() const
++{
++    if (!m_context)
++        return false;
++    return !m_context->creationAttributes().hasAlpha();
++}
++
+ CanvasRenderingContext* OffscreenCanvas::getCanvasRenderingContext(ScriptState* scriptState, const String& id, const CanvasContextCreationAttributes& attributes)
+ {
+     CanvasRenderingContext::ContextType contextType = CanvasRenderingContext::contextTypeFromId(id);
+diff --git a/third_party/WebKit/Source/core/offscreencanvas/OffscreenCanvas.h b/third_party/WebKit/Source/core/offscreencanvas/OffscreenCanvas.h
+index 94d25bebdbcf7efb331743efa665e1a3902184ea..162b2b874905d3185100ee844a0c8b06c5cfb778 100644
+--- a/third_party/WebKit/Source/core/offscreencanvas/OffscreenCanvas.h
++++ b/third_party/WebKit/Source/core/offscreencanvas/OffscreenCanvas.h
+@@ -9,6 +9,7 @@
+ #include "bindings/core/v8/ScriptState.h"
+ #include "bindings/core/v8/ScriptWrappable.h"
+ #include "core/html/HTMLCanvasElement.h"
++#include "core/html/canvas/CanvasImageSource.h"
+ #include "platform/geometry/IntSize.h"
+ #include "platform/heap/Handle.h"
+ #include <memory>
+@@ -20,7 +21,7 @@ class ImageBitmap;
+ class OffscreenCanvasRenderingContext2DOrWebGLRenderingContextOrWebGL2RenderingContext;
+ typedef OffscreenCanvasRenderingContext2DOrWebGLRenderingContextOrWebGL2RenderingContext OffscreenRenderingContext;
+ 
+-class CORE_EXPORT OffscreenCanvas final : public GarbageCollected<OffscreenCanvas>, public ScriptWrappable {
++class CORE_EXPORT OffscreenCanvas final : public GarbageCollectedFinalized<OffscreenCanvas>, public ScriptWrappable, public CanvasImageSource {
+     DEFINE_WRAPPERTYPEINFO();
+ public:
+     static OffscreenCanvas* create(unsigned width, unsigned height);
+@@ -59,6 +60,15 @@ public:
+     uint32_t localId() const { return m_localId; }
+     uint64_t nonce() const { return m_nonce; }
+ 
++    // CanvasImageSource implementation
++    PassRefPtr<Image> getSourceImageForCanvas(SourceImageStatus*, AccelerationHint, SnapshotReason, const FloatSize&) const final;
++    bool wouldTaintOrigin(SecurityOrigin*) const final { return !m_originClean; }
++    bool isOffscreenCanvas() const final { return true; }
++    FloatSize elementSize(const FloatSize& defaultObjectSize) const final { return FloatSize(width(), height()); }
++    bool isOpaque() const final;
++    int sourceWidth() final { return width(); }
++    int sourceHeight() final { return height(); }
++
+     DECLARE_VIRTUAL_TRACE();
+ 
+ private:
+diff --git a/third_party/WebKit/Source/core/paint/BoxReflectionUtils.cpp b/third_party/WebKit/Source/core/paint/BoxReflectionUtils.cpp
+index a3fc5d14b3238e67cd6f65f58e3813d5ac8e768b..395486d917147827c67b72bc89fe83bf3a5737c0 100644
+--- a/third_party/WebKit/Source/core/paint/BoxReflectionUtils.cpp
++++ b/third_party/WebKit/Source/core/paint/BoxReflectionUtils.cpp
+@@ -44,7 +44,7 @@ BoxReflection boxReflectionForPaintLayer(const PaintLayer& layer, const Computed
+         break;
+     }
+ 
+-    RefPtr<SkPicture> mask;
++    sk_sp<SkPicture> mask;
+     const NinePieceImage& maskNinePiece = reflectStyle->mask();
+     if (maskNinePiece.hasImage()) {
+         LayoutRect maskRect(LayoutPoint(), frameLayoutRect.size());
+@@ -65,7 +65,7 @@ BoxReflection boxReflectionForPaintLayer(const PaintLayer& layer, const Computed
+         mask = recorder.endRecording();
+     }
+ 
+-    return BoxReflection(direction, offset, mask);
++    return BoxReflection(direction, offset, std::move(mask));
+ }
+ 
+ } // namespace blink
+diff --git a/third_party/WebKit/Source/core/paint/SVGClipPainter.cpp b/third_party/WebKit/Source/core/paint/SVGClipPainter.cpp
+index b16d37e952e2c79e64fd634f9597b3cd48f7c201..c4a9c966fa386f6b848f2799137e2586633e34d2 100644
+--- a/third_party/WebKit/Source/core/paint/SVGClipPainter.cpp
++++ b/third_party/WebKit/Source/core/paint/SVGClipPainter.cpp
+@@ -130,8 +130,7 @@ bool SVGClipPainter::drawClipAsMask(GraphicsContext& context, const LayoutObject
+             SubtreeContentTransformScope contentTransformScope(contentTransform);
+ 
+             TransformRecorder contentTransformRecorder(maskContext, layoutObject, contentTransform);
+-            RefPtr<const SkPicture> clipContentPicture = m_clip.createContentPicture();
+-            maskContext.getPaintController().createAndAppend<DrawingDisplayItem>(layoutObject, DisplayItem::SVGClip, clipContentPicture.get());
++            maskContext.getPaintController().createAndAppend<DrawingDisplayItem>(layoutObject, DisplayItem::SVGClip, m_clip.createContentPicture());
+         }
+ 
+         if (clipPathClipper)
+@@ -139,7 +138,7 @@ bool SVGClipPainter::drawClipAsMask(GraphicsContext& context, const LayoutObject
+     }
+ 
+     LayoutObjectDrawingRecorder drawingRecorder(context, layoutObject, DisplayItem::SVGClip, targetPaintInvalidationRect);
+-    RefPtr<SkPicture> maskPicture = maskPictureBuilder.endRecording();
++    sk_sp<SkPicture> maskPicture = maskPictureBuilder.endRecording();
+     context.drawPicture(maskPicture.get());
+     return true;
+ }
+diff --git a/third_party/WebKit/Source/core/paint/SVGFilterPainter.cpp b/third_party/WebKit/Source/core/paint/SVGFilterPainter.cpp
+index 0bf57810d3397fef157f301a1f9d8119b3f503a9..8a445aaa2aa673f3bef2afa04bf4f0c25449752e 100644
+--- a/third_party/WebKit/Source/core/paint/SVGFilterPainter.cpp
++++ b/third_party/WebKit/Source/core/paint/SVGFilterPainter.cpp
+@@ -39,7 +39,7 @@ void SVGFilterRecordingContext::endContent(FilterData* filterData)
+     m_paintController->commitNewDisplayItems();
+     m_paintController->paintArtifact().replay(*m_context);
+ 
+-    SkiaImageFilterBuilder::buildSourceGraphic(sourceGraphic, toSkSp(m_context->endRecording()));
++    SkiaImageFilterBuilder::buildSourceGraphic(sourceGraphic, m_context->endRecording());
+ 
+     // Content is cached by the source graphic so temporaries can be freed.
+     m_paintController = nullptr;
+diff --git a/third_party/WebKit/Source/core/paint/SVGInlineTextBoxPainter.cpp b/third_party/WebKit/Source/core/paint/SVGInlineTextBoxPainter.cpp
+index 620f0d59faf906ead6a11a8ee8a085c46e52815f..efaabaabb8b1d4ab8f8b7643687fda904bf33465 100644
+--- a/third_party/WebKit/Source/core/paint/SVGInlineTextBoxPainter.cpp
++++ b/third_party/WebKit/Source/core/paint/SVGInlineTextBoxPainter.cpp
+@@ -352,7 +352,7 @@ bool SVGInlineTextBoxPainter::setupTextPaint(const PaintInfo& paintInfo, const C
+ 
+     if (hasShadow(paintInfo, style)) {
+         std::unique_ptr<DrawLooperBuilder> drawLooperBuilder = style.textShadow()->createDrawLooper(DrawLooperBuilder::ShadowRespectsAlpha, style.visitedDependentColor(CSSPropertyColor));
+-        paint.setLooper(toSkSp(drawLooperBuilder->detachDrawLooper()));
++        paint.setLooper(drawLooperBuilder->detachDrawLooper());
+     }
+ 
+     if (resourceMode == ApplyToStrokeMode) {
+diff --git a/third_party/WebKit/Source/core/paint/SVGMaskPainter.cpp b/third_party/WebKit/Source/core/paint/SVGMaskPainter.cpp
+index a6f534ed45df2d9c8c418676058851c48878d2ed..8f6f42470b3551001257c320ca3b75e2d6a76800 100644
+--- a/third_party/WebKit/Source/core/paint/SVGMaskPainter.cpp
++++ b/third_party/WebKit/Source/core/paint/SVGMaskPainter.cpp
+@@ -49,7 +49,7 @@ void SVGMaskPainter::finishEffect(const LayoutObject& object, GraphicsContext& c
+ void SVGMaskPainter::drawMaskForLayoutObject(GraphicsContext& context, const LayoutObject& layoutObject, const FloatRect& targetBoundingBox, const FloatRect& targetPaintInvalidationRect)
+ {
+     AffineTransform contentTransformation;
+-    RefPtr<const SkPicture> maskContentPicture = m_mask.createContentPicture(contentTransformation, targetBoundingBox, context);
++    sk_sp<const SkPicture> maskContentPicture = m_mask.createContentPicture(contentTransformation, targetBoundingBox, context);
+ 
+     if (LayoutObjectDrawingRecorder::useCachedDrawingIfPossible(context, layoutObject, DisplayItem::SVGMask))
+         return;
+diff --git a/third_party/WebKit/Source/core/svg/graphics/SVGImage.cpp b/third_party/WebKit/Source/core/svg/graphics/SVGImage.cpp
+index 1b3137e1d2bb100d5a6662a9a4ab3e8fd3398926..771d1811ccc3897b2b770ec2e613a03552541f84 100644
+--- a/third_party/WebKit/Source/core/svg/graphics/SVGImage.cpp
++++ b/third_party/WebKit/Source/core/svg/graphics/SVGImage.cpp
+@@ -259,7 +259,7 @@ void SVGImage::drawForContainer(SkCanvas* canvas, const SkPaint& paint, const Fl
+     drawInternal(canvas, paint, dstRect, scaledSrc, DoNotRespectImageOrientation, ClampImageToSourceRect, url);
+ }
+ 
+-PassRefPtr<SkImage> SVGImage::imageForCurrentFrame()
++sk_sp<SkImage> SVGImage::imageForCurrentFrame()
+ {
+     return imageForCurrentFrameForContainer(KURL(), FloatSize(size()));
+ }
+@@ -286,20 +286,20 @@ void SVGImage::drawPatternForContainer(GraphicsContext& context, const FloatSize
+         SkPaint paint;
+         drawForContainer(patternPicture.context().canvas(), paint, containerSize, zoom, tile, srcRect, url);
+     }
+-    RefPtr<SkPicture> tilePicture = patternPicture.endRecording();
++    sk_sp<SkPicture> tilePicture = patternPicture.endRecording();
+ 
+     SkMatrix patternTransform;
+     patternTransform.setTranslate(phase.x() + spacedTile.x(), phase.y() + spacedTile.y());
+ 
+     SkPaint paint;
+-    paint.setShader(SkShader::MakePictureShader(toSkSp(tilePicture.release()),
++    paint.setShader(SkShader::MakePictureShader(std::move(tilePicture),
+         SkShader::kRepeat_TileMode, SkShader::kRepeat_TileMode, &patternTransform, nullptr));
+     paint.setXfermodeMode(compositeOp);
+     paint.setColorFilter(sk_ref_sp(context.colorFilter()));
+     context.drawRect(dstRect, paint);
+ }
+ 
+-PassRefPtr<SkImage> SVGImage::imageForCurrentFrameForContainer(const KURL& url, const FloatSize& containerSize)
++sk_sp<SkImage> SVGImage::imageForCurrentFrameForContainer(const KURL& url, const FloatSize& containerSize)
+ {
+     if (!m_page)
+         return nullptr;
+@@ -314,8 +314,8 @@ PassRefPtr<SkImage> SVGImage::imageForCurrentFrameForContainer(const KURL& url,
+     const SkMatrix residualScale = SkMatrix::MakeScale(
+         static_cast<float>(imageSize.width()) / containerSize.width(),
+         static_cast<float>(imageSize.height()) / containerSize.height());
+-    return fromSkSp(SkImage::MakeFromPicture(recorder.finishRecordingAsPicture(),
+-        SkISize::Make(imageSize.width(), imageSize.height()), &residualScale, nullptr));
++    return SkImage::MakeFromPicture(recorder.finishRecordingAsPicture(),
++        SkISize::Make(imageSize.width(), imageSize.height()), &residualScale, nullptr);
+ }
+ 
+ static bool drawNeedsLayer(const SkPaint& paint)
+@@ -383,7 +383,7 @@ void SVGImage::drawInternal(SkCanvas* canvas, const SkPaint& paint, const FloatR
+             SkRect layerRect = dstRect;
+             canvas->saveLayer(&layerRect, &paint);
+         }
+-        RefPtr<const SkPicture> recording = imagePicture.endRecording();
++        sk_sp<const SkPicture> recording = imagePicture.endRecording();
+         canvas->drawPicture(recording.get());
+     }
+ 
+diff --git a/third_party/WebKit/Source/core/svg/graphics/SVGImage.h b/third_party/WebKit/Source/core/svg/graphics/SVGImage.h
+index a46d63881bdb85e6180832e54cf685619852b9f1..26a54064108e735c2112dab550f9c460386dbe57 100644
+--- a/third_party/WebKit/Source/core/svg/graphics/SVGImage.h
++++ b/third_party/WebKit/Source/core/svg/graphics/SVGImage.h
+@@ -31,6 +31,7 @@
+ #include "platform/graphics/Image.h"
+ #include "platform/heap/Handle.h"
+ #include "platform/weborigin/KURL.h"
++#include "third_party/skia/include/core/SkRefCnt.h"
+ #include "wtf/Allocator.h"
+ 
+ namespace blink {
+@@ -66,7 +67,7 @@ public:
+     void advanceAnimationForTesting() override;
+     SVGImageChromeClient& chromeClientForTesting();
+ 
+-    PassRefPtr<SkImage> imageForCurrentFrame() override;
++    sk_sp<SkImage> imageForCurrentFrame() override;
+ 
+     // Does the SVG image/document contain any animations?
+     bool hasAnimations() const;
+@@ -110,7 +111,7 @@ private:
+     void drawForContainer(SkCanvas*, const SkPaint&, const FloatSize, float, const FloatRect&, const FloatRect&, const KURL&);
+     void drawPatternForContainer(GraphicsContext&, const FloatSize, float, const FloatRect&, const FloatSize&, const FloatPoint&,
+         SkXfermode::Mode, const FloatRect&, const FloatSize& repeatSpacing, const KURL&);
+-    PassRefPtr<SkImage> imageForCurrentFrameForContainer(const KURL&, const FloatSize& containerSize);
++    sk_sp<SkImage> imageForCurrentFrameForContainer(const KURL&, const FloatSize& containerSize);
+     void drawInternal(SkCanvas*, const SkPaint&, const FloatRect& fromRect, const FloatRect& toRect, RespectImageOrientationEnum,
+         ImageClampingMode, const KURL&);
+ 
+diff --git a/third_party/WebKit/Source/core/svg/graphics/SVGImageForContainer.cpp b/third_party/WebKit/Source/core/svg/graphics/SVGImageForContainer.cpp
+index 3a2a1ce5507a026123683cd4023d87d1918d34a6..1cde782814b76184b8e2d13e35074b6e4ca8b443 100644
+--- a/third_party/WebKit/Source/core/svg/graphics/SVGImageForContainer.cpp
++++ b/third_party/WebKit/Source/core/svg/graphics/SVGImageForContainer.cpp
+@@ -51,7 +51,7 @@ void SVGImageForContainer::drawPattern(GraphicsContext& context, const FloatRect
+     m_image->drawPatternForContainer(context, m_containerSize, m_zoom, srcRect, scale, phase, op, dstRect, repeatSpacing, m_url);
+ }
+ 
+-PassRefPtr<SkImage> SVGImageForContainer::imageForCurrentFrame()
++sk_sp<SkImage> SVGImageForContainer::imageForCurrentFrame()
+ {
+     return m_image->imageForCurrentFrameForContainer(m_url, m_containerSize);
+ }
+diff --git a/third_party/WebKit/Source/core/svg/graphics/SVGImageForContainer.h b/third_party/WebKit/Source/core/svg/graphics/SVGImageForContainer.h
+index 40ba819bc5ffb46ceeb6d10b729226ee90e2ec5a..694783e33c8c53a1b9047192de0eb85e0f923d51 100644
+--- a/third_party/WebKit/Source/core/svg/graphics/SVGImageForContainer.h
++++ b/third_party/WebKit/Source/core/svg/graphics/SVGImageForContainer.h
+@@ -31,6 +31,7 @@
+ #include "platform/geometry/FloatSize.h"
+ #include "platform/graphics/Image.h"
+ #include "platform/weborigin/KURL.h"
++#include "third_party/skia/include/core/SkRefCnt.h"
+ 
+ namespace blink {
+ 
+@@ -57,7 +58,7 @@ public:
+     // FIXME: Implement this to be less conservative.
+     bool currentFrameKnownToBeOpaque(MetadataMode = UseCurrentMetadata) override { return false; }
+ 
+-    PassRefPtr<SkImage> imageForCurrentFrame() override;
++    sk_sp<SkImage> imageForCurrentFrame() override;
+ 
+ private:
+     SVGImageForContainer(SVGImage* image, const FloatSize& containerSize, float zoom, const KURL& url)
+diff --git a/third_party/WebKit/Source/core/svg/graphics/SVGImageTest.cpp b/third_party/WebKit/Source/core/svg/graphics/SVGImageTest.cpp
+index a173e77092d31ae512dea3e257d205fcc4235cbf..f62d5701e068245ecf31881c65a6ecc583138e45 100644
+--- a/third_party/WebKit/Source/core/svg/graphics/SVGImageTest.cpp
++++ b/third_party/WebKit/Source/core/svg/graphics/SVGImageTest.cpp
+@@ -89,7 +89,7 @@ public:
+     void pumpFrame()
+     {
+         Image* image = m_image.get();
+-        RefPtr<SkCanvas> nullCanvas = adoptRef(SkCreateNullCanvas());
++        sk_sp<SkCanvas> nullCanvas(SkCreateNullCanvas());
+         SkPaint paint;
+         FloatRect dummyRect(0, 0, 100, 100);
+         image->draw(
+diff --git a/third_party/WebKit/Source/core/svg/graphics/filters/SVGFEImage.cpp b/third_party/WebKit/Source/core/svg/graphics/filters/SVGFEImage.cpp
+index 47751537e73727faa5fb8cd7614d263bd725b268..dae27f5280360db2af388fec7d1cb1a76101af7f 100644
+--- a/third_party/WebKit/Source/core/svg/graphics/filters/SVGFEImage.cpp
++++ b/third_party/WebKit/Source/core/svg/graphics/filters/SVGFEImage.cpp
+@@ -178,7 +178,7 @@ sk_sp<SkImageFilter> FEImage::createImageFilterForLayoutObject(const LayoutObjec
+         SVGPaintContext::paintSubtree(filterPicture.context(), &layoutObject);
+     }
+ 
+-    return SkPictureImageFilter::Make(toSkSp(filterPicture.endRecording()), dstRect);
++    return SkPictureImageFilter::Make(filterPicture.endRecording(), dstRect);
+ }
+ 
+ sk_sp<SkImageFilter> FEImage::createImageFilter()
+@@ -186,7 +186,7 @@ sk_sp<SkImageFilter> FEImage::createImageFilter()
+     if (auto* layoutObject = referencedLayoutObject())
+         return createImageFilterForLayoutObject(*layoutObject);
+ 
+-    sk_sp<SkImage> image = m_image ? toSkSp(m_image->imageForCurrentFrame()) : nullptr;
++    sk_sp<SkImage> image = m_image ? m_image->imageForCurrentFrame() : nullptr;
+     if (!image) {
+         // "A href reference that is an empty image (zero width or zero height), that fails
+         // to download, is non-existent, or that cannot be displayed (e.g. because it is
+diff --git a/third_party/WebKit/Source/modules/canvas2d/BaseRenderingContext2D.cpp b/third_party/WebKit/Source/modules/canvas2d/BaseRenderingContext2D.cpp
+index 8f80b02040daa0f04f29f6c585c61e1dd5c5e908..c1c2227181b529b8306a0e872619ca7e671e66ec 100644
+--- a/third_party/WebKit/Source/modules/canvas2d/BaseRenderingContext2D.cpp
++++ b/third_party/WebKit/Source/modules/canvas2d/BaseRenderingContext2D.cpp
+@@ -13,6 +13,7 @@
+ #include "core/html/HTMLImageElement.h"
+ #include "core/html/HTMLVideoElement.h"
+ #include "core/html/ImageData.h"
++#include "core/offscreencanvas/OffscreenCanvas.h"
+ #include "modules/canvas2d/CanvasGradient.h"
+ #include "modules/canvas2d/CanvasPattern.h"
+ #include "modules/canvas2d/CanvasStyle.h"
+@@ -878,6 +879,13 @@ static inline CanvasImageSource* toImageSourceInternal(const CanvasImageSourceUn
+         }
+         return value.getAsImageBitmap();
+     }
++    if (value.isOffscreenCanvas()) {
++        if (static_cast<OffscreenCanvas*>(value.getAsOffscreenCanvas())->isNeutered()) {
++            exceptionState.throwDOMException(InvalidStateError, String::format("The image source is detached"));
++            return nullptr;
++        }
++        return value.getAsOffscreenCanvas();
++    }
+     ASSERT_NOT_REACHED();
+     return nullptr;
+ }
+diff --git a/third_party/WebKit/Source/modules/canvas2d/BaseRenderingContext2D.h b/third_party/WebKit/Source/modules/canvas2d/BaseRenderingContext2D.h
+index 10ce134c780a911270b99f72ff396902fbdb271a..e775d92107388275b4ff5661326b74d0b6faed62 100644
+--- a/third_party/WebKit/Source/modules/canvas2d/BaseRenderingContext2D.h
++++ b/third_party/WebKit/Source/modules/canvas2d/BaseRenderingContext2D.h
+@@ -5,7 +5,7 @@
+ #ifndef BaseRenderingContext2D_h
+ #define BaseRenderingContext2D_h
+ 
+-#include "bindings/modules/v8/HTMLImageElementOrHTMLVideoElementOrHTMLCanvasElementOrImageBitmap.h"
++#include "bindings/modules/v8/HTMLImageElementOrHTMLVideoElementOrHTMLCanvasElementOrImageBitmapOrOffscreenCanvas.h"
+ #include "bindings/modules/v8/StringOrCanvasGradientOrCanvasPattern.h"
+ #include "core/html/ImageData.h"
+ #include "modules/ModulesExport.h"
+@@ -25,7 +25,7 @@ class ImageBuffer;
+ class Path2D;
+ class SVGMatrixTearOff;
+ 
+-typedef HTMLImageElementOrHTMLVideoElementOrHTMLCanvasElementOrImageBitmap CanvasImageSourceUnion;
++typedef HTMLImageElementOrHTMLVideoElementOrHTMLCanvasElementOrImageBitmapOrOffscreenCanvas CanvasImageSourceUnion;
+ 
+ class MODULES_EXPORT BaseRenderingContext2D : public GarbageCollectedMixin, public CanvasPathMethods {
+     WTF_MAKE_NONCOPYABLE(BaseRenderingContext2D);
+diff --git a/third_party/WebKit/Source/modules/canvas2d/CanvasRenderingContext2D.cpp b/third_party/WebKit/Source/modules/canvas2d/CanvasRenderingContext2D.cpp
+index d814994ba1b81b080c15bc276c6b3fcfea28093f..7ed92b6519451a28632b62f57b4895c3ebea6a3e 100644
+--- a/third_party/WebKit/Source/modules/canvas2d/CanvasRenderingContext2D.cpp
++++ b/third_party/WebKit/Source/modules/canvas2d/CanvasRenderingContext2D.cpp
+@@ -584,6 +584,13 @@ ImageBuffer* CanvasRenderingContext2D::imageBuffer() const
+     return canvas()->buffer();
+ }
+ 
++PassRefPtr<Image> blink::CanvasRenderingContext2D::getImage(SnapshotReason reason) const
++{
++    if (!hasImageBuffer())
++        return nullptr;
++    return canvas()->buffer()->newImageSnapshot(PreferAcceleration, reason);
++}
++
+ bool CanvasRenderingContext2D::parseColorOrCurrentColor(Color& color, const String& colorString) const
+ {
+     return ::blink::parseColorOrCurrentColor(color, colorString, canvas());
+diff --git a/third_party/WebKit/Source/modules/canvas2d/CanvasRenderingContext2D.h b/third_party/WebKit/Source/modules/canvas2d/CanvasRenderingContext2D.h
+index 641db101c3776b95175ab897a547e01a90086dd9..87e757d910baacaf2c7d67881b4c7c32981d0e0a 100644
+--- a/third_party/WebKit/Source/modules/canvas2d/CanvasRenderingContext2D.h
++++ b/third_party/WebKit/Source/modules/canvas2d/CanvasRenderingContext2D.h
+@@ -60,7 +60,7 @@ class Path2D;
+ class SVGMatrixTearOff;
+ class TextMetrics;
+ 
+-typedef HTMLImageElementOrHTMLVideoElementOrHTMLCanvasElementOrImageBitmap CanvasImageSourceUnion;
++typedef HTMLImageElementOrHTMLVideoElementOrHTMLCanvasElementOrImageBitmapOrOffscreenCanvas CanvasImageSourceUnion;
+ 
+ class MODULES_EXPORT CanvasRenderingContext2D final : public CanvasRenderingContext, public BaseRenderingContext2D, public WebThread::TaskObserver, public SVGResourceClient {
+     DEFINE_WRAPPERTYPEINFO();
+@@ -167,11 +167,15 @@ public:
+ 
+     void validateStateStack() final;
+ 
++    PassRefPtr<Image> getImage(SnapshotReason) const final;
++
+     bool isAccelerationOptimalForCanvasContent() const;
+ 
+     void resetUsageTracking();
+ 
+-    void incrementFrameCount() { m_usageCounters.numFramesSinceReset++; };
++    void incrementFrameCount() { m_usageCounters.numFramesSinceReset++; }
++
++    bool isPaintable() const final { return hasImageBuffer(); }
+ 
+ private:
+     friend class CanvasRenderingContext2DAutoRestoreSkCanvas;
+@@ -224,12 +228,6 @@ private:
+     HashMap<String, Font> m_fontsResolvedUsingCurrentStyle;
+     bool m_pruneLocalFontCacheScheduled;
+     ListHashSet<String> m_fontLRUList;
+-
+-    bool isPaintable() const final
+-    {
+-        NOTREACHED();
+-        return false;
+-    }
+ };
+ 
+ DEFINE_TYPE_CASTS(CanvasRenderingContext2D, CanvasRenderingContext, context,
+diff --git a/third_party/WebKit/Source/modules/canvas2d/CanvasRenderingContext2D.idl b/third_party/WebKit/Source/modules/canvas2d/CanvasRenderingContext2D.idl
+index d8a96bbf4ee9646ad8052578829b611c0a10f4d8..33fb3989c2358f7f42180cd7a9497694ea8d4045 100644
+--- a/third_party/WebKit/Source/modules/canvas2d/CanvasRenderingContext2D.idl
++++ b/third_party/WebKit/Source/modules/canvas2d/CanvasRenderingContext2D.idl
+@@ -28,8 +28,8 @@
+ typedef (HTMLImageElement or
+          HTMLVideoElement or
+          HTMLCanvasElement or
+-         // CanvasRenderingContext2D or
+-         ImageBitmap) CanvasImageSource;
++         ImageBitmap or
++         OffscreenCanvas) CanvasImageSource;
+ 
+ enum CanvasFillRule { "nonzero", "evenodd" };
+ enum ImageSmoothingQuality {"low", "medium", "high"};
+diff --git a/third_party/WebKit/Source/modules/canvas2d/CanvasRenderingContext2DState.cpp b/third_party/WebKit/Source/modules/canvas2d/CanvasRenderingContext2DState.cpp
+index 24a50bc02fedbd88d78c6fab12f9dedb2693f3ee..0bf262363c3a94929b1ebcc1098e18204418cb50 100644
+--- a/third_party/WebKit/Source/modules/canvas2d/CanvasRenderingContext2DState.cpp
++++ b/third_party/WebKit/Source/modules/canvas2d/CanvasRenderingContext2DState.cpp
+@@ -399,8 +399,8 @@ SkImageFilter* CanvasRenderingContext2DState::shadowAndForegroundImageFilter() c
+ 
+ void CanvasRenderingContext2DState::shadowParameterChanged()
+ {
+-    m_shadowOnlyDrawLooper.clear();
+-    m_shadowAndForegroundDrawLooper.clear();
++    m_shadowOnlyDrawLooper.reset();
++    m_shadowAndForegroundDrawLooper.reset();
+     m_shadowOnlyImageFilter.reset();
+     m_shadowAndForegroundImageFilter.reset();
+ }
+diff --git a/third_party/WebKit/Source/modules/canvas2d/CanvasRenderingContext2DState.h b/third_party/WebKit/Source/modules/canvas2d/CanvasRenderingContext2DState.h
+index 25347e62086cfee8169ed4e1c83dcc00263dc12e..131c647f47b1da8171742b3501470eb2b0085223 100644
+--- a/third_party/WebKit/Source/modules/canvas2d/CanvasRenderingContext2DState.h
++++ b/third_party/WebKit/Source/modules/canvas2d/CanvasRenderingContext2DState.h
+@@ -9,6 +9,7 @@
+ #include "modules/canvas2d/ClipList.h"
+ #include "platform/fonts/Font.h"
+ #include "platform/transforms/AffineTransform.h"
++#include "third_party/skia/include/core/SkRefCnt.h"
+ #include "wtf/Vector.h"
+ 
+ namespace blink {
+@@ -194,9 +195,9 @@ private:
+     FloatSize m_shadowOffset;
+     double m_shadowBlur;
+     SkColor m_shadowColor;
+-    mutable RefPtr<SkDrawLooper> m_emptyDrawLooper;
+-    mutable RefPtr<SkDrawLooper> m_shadowOnlyDrawLooper;
+-    mutable RefPtr<SkDrawLooper> m_shadowAndForegroundDrawLooper;
++    mutable sk_sp<SkDrawLooper> m_emptyDrawLooper;
++    mutable sk_sp<SkDrawLooper> m_shadowOnlyDrawLooper;
++    mutable sk_sp<SkDrawLooper> m_shadowAndForegroundDrawLooper;
+     mutable sk_sp<SkImageFilter> m_shadowOnlyImageFilter;
+     mutable sk_sp<SkImageFilter> m_shadowAndForegroundImageFilter;
+ 
+diff --git a/third_party/WebKit/Source/modules/canvas2d/CanvasRenderingContext2DTest.cpp b/third_party/WebKit/Source/modules/canvas2d/CanvasRenderingContext2DTest.cpp
+index 10328bb9f294ea02044e1fcd58f93bd3ee72c6d7..f1dae59bea806c20622bb38b80f5dfcbf29b4a67 100644
+--- a/third_party/WebKit/Source/modules/canvas2d/CanvasRenderingContext2DTest.cpp
++++ b/third_party/WebKit/Source/modules/canvas2d/CanvasRenderingContext2DTest.cpp
+@@ -64,8 +64,7 @@ FakeImageSource::FakeImageSource(IntSize size, BitmapOpacity opacity)
+ {
+     sk_sp<SkSurface> surface(SkSurface::MakeRasterN32Premul(m_size.width(), m_size.height()));
+     surface->getCanvas()->clear(opacity == OpaqueBitmap ? SK_ColorWHITE : SK_ColorTRANSPARENT);
+-    RefPtr<SkImage> image = fromSkSp(surface->makeImageSnapshot());
+-    m_image = StaticBitmapImage::create(image);
++    m_image = StaticBitmapImage::create(surface->makeImageSnapshot());
+ }
+ 
+ PassRefPtr<Image> FakeImageSource::getSourceImageForCanvas(SourceImageStatus* status, AccelerationHint, SnapshotReason, const FloatSize&) const
+diff --git a/third_party/WebKit/Source/modules/canvas2d/CanvasRenderingContext2DUsageTrackingTest.cpp b/third_party/WebKit/Source/modules/canvas2d/CanvasRenderingContext2DUsageTrackingTest.cpp
+index 08934b2b1f6b2f02bdb029231fb7c257f3953ea7..a14184f17a601f45c4e4e04ea71c4f18823bff7a 100644
+--- a/third_party/WebKit/Source/modules/canvas2d/CanvasRenderingContext2DUsageTrackingTest.cpp
++++ b/third_party/WebKit/Source/modules/canvas2d/CanvasRenderingContext2DUsageTrackingTest.cpp
+@@ -60,8 +60,7 @@ FakeImageSource::FakeImageSource(IntSize size, BitmapOpacity opacity)
+ {
+     sk_sp<SkSurface> surface(SkSurface::MakeRasterN32Premul(m_size.width(), m_size.height()));
+     surface->getCanvas()->clear(opacity == OpaqueBitmap ? SK_ColorWHITE : SK_ColorTRANSPARENT);
+-    RefPtr<SkImage> image = adoptRef(surface->makeImageSnapshot().release());
+-    m_image = StaticBitmapImage::create(image);
++    m_image = StaticBitmapImage::create(surface->makeImageSnapshot());
+ }
+ 
+ PassRefPtr<Image> FakeImageSource::getSourceImageForCanvas(SourceImageStatus* status, AccelerationHint, SnapshotReason, const FloatSize&) const
+diff --git a/third_party/WebKit/Source/modules/fetch/FetchFormDataConsumerHandle.h b/third_party/WebKit/Source/modules/fetch/FetchFormDataConsumerHandle.h
+index af0ae1cf0d889a53bc3abb271ce79fd9ed230112..90ee589db49e5ec486ee109804e42b25b4347f3c 100644
+--- a/third_party/WebKit/Source/modules/fetch/FetchFormDataConsumerHandle.h
++++ b/third_party/WebKit/Source/modules/fetch/FetchFormDataConsumerHandle.h
+@@ -49,7 +49,7 @@ private:
+ 
+     explicit FetchFormDataConsumerHandle(const String& body);
+     FetchFormDataConsumerHandle(const void*, size_t);
+-    FetchFormDataConsumerHandle(ExecutionContext*, const PassRefPtr<EncodedFormData> body, FetchBlobDataConsumerHandle::LoaderFactory* = nullptr);
++    FetchFormDataConsumerHandle(ExecutionContext*, PassRefPtr<EncodedFormData> body, FetchBlobDataConsumerHandle::LoaderFactory* = nullptr);
+ 
+     std::unique_ptr<Reader> obtainFetchDataReader(Client*) override;
+ 
+diff --git a/third_party/WebKit/Source/modules/imagebitmap/ImageBitmapRenderingContext.cpp b/third_party/WebKit/Source/modules/imagebitmap/ImageBitmapRenderingContext.cpp
+index 7f7c5744c6ecfc23c242710a9b8c4a64d3b44452..2c236ac467ccce55bb4875da8e7aa26bfb65c7bf 100644
+--- a/third_party/WebKit/Source/modules/imagebitmap/ImageBitmapRenderingContext.cpp
++++ b/third_party/WebKit/Source/modules/imagebitmap/ImageBitmapRenderingContext.cpp
+@@ -35,7 +35,7 @@ void ImageBitmapRenderingContext::transferFromImageBitmap(ImageBitmap* imageBitm
+     if (!m_image)
+         return;
+ 
+-    RefPtr<SkImage> skImage = m_image->imageForCurrentFrame();
++    sk_sp<SkImage> skImage = m_image->imageForCurrentFrame();
+     if (skImage->isTextureBacked()) {
+         // TODO(junov): crbug.com/585607 Eliminate this readback and use an ExternalTextureLayer
+         sk_sp<SkSurface> surface = SkSurface::MakeRasterN32Premul(skImage->width(), skImage->height());
+@@ -44,8 +44,8 @@ void ImageBitmapRenderingContext::transferFromImageBitmap(ImageBitmap* imageBitm
+             m_image.clear();
+             return;
+         }
+-        surface->getCanvas()->drawImage(skImage.get(), 0, 0);
+-        m_image = StaticBitmapImage::create(fromSkSp(surface->makeImageSnapshot()));
++        surface->getCanvas()->drawImage(skImage, 0, 0);
++        m_image = StaticBitmapImage::create(surface->makeImageSnapshot());
+     }
+     canvas()->didDraw(FloatRect(FloatPoint(), FloatSize(m_image->width(), m_image->height())));
+ }
+diff --git a/third_party/WebKit/Source/modules/imagebitmap/ImageBitmapRenderingContext.h b/third_party/WebKit/Source/modules/imagebitmap/ImageBitmapRenderingContext.h
+index 2d636363598c5a5adfca750f640e9db2bf9f42d1..cfb715a377d679452eae14d2d443bffb49908b07 100644
+--- a/third_party/WebKit/Source/modules/imagebitmap/ImageBitmapRenderingContext.h
++++ b/third_party/WebKit/Source/modules/imagebitmap/ImageBitmapRenderingContext.h
+@@ -36,7 +36,7 @@ public:
+     bool isContextLost() const override { return false; }
+     bool paint(GraphicsContext&, const IntRect&) override;
+     void setCanvasGetContextResult(RenderingContext&) final;
+-    PassRefPtr<Image> getImage() const final { return m_image.get(); }
++    PassRefPtr<Image> getImage(SnapshotReason) const final { return m_image.get(); }
+ 
+     // TODO(junov): Implement GPU accelerated rendering using a layer bridge
+     WebLayer* platformLayer() const override { return nullptr; }
+@@ -45,14 +45,14 @@ public:
+ 
+     void stop() override;
+ 
++    bool isPaintable() const final { return m_image.get(); }
++
+     virtual ~ImageBitmapRenderingContext();
+ 
+ private:
+     ImageBitmapRenderingContext(HTMLCanvasElement*, const CanvasContextCreationAttributes&, Document&);
+ 
+     RefPtr<Image> m_image;
+-
+-    bool isPaintable() const final { return m_image.get(); }
+ };
+ 
+ DEFINE_TYPE_CASTS(ImageBitmapRenderingContext, CanvasRenderingContext, context,
+diff --git a/third_party/WebKit/Source/modules/mediacapturefromelement/OnRequestCanvasDrawListener.cpp b/third_party/WebKit/Source/modules/mediacapturefromelement/OnRequestCanvasDrawListener.cpp
+index 2cad4d357440db55dcc89c827b1b1ddd8d30b665..8a3680b67a1a92f0f9a230509cf33066b9c2c9e1 100644
+--- a/third_party/WebKit/Source/modules/mediacapturefromelement/OnRequestCanvasDrawListener.cpp
++++ b/third_party/WebKit/Source/modules/mediacapturefromelement/OnRequestCanvasDrawListener.cpp
+@@ -4,6 +4,7 @@
+ 
+ #include "modules/mediacapturefromelement/OnRequestCanvasDrawListener.h"
+ 
++#include "third_party/skia/include/core/SkImage.h"
+ #include <memory>
+ 
+ namespace blink {
+@@ -21,10 +22,10 @@ OnRequestCanvasDrawListener* OnRequestCanvasDrawListener::create(std::unique_ptr
+     return new OnRequestCanvasDrawListener(std::move(handler));
+ }
+ 
+-void OnRequestCanvasDrawListener::sendNewFrame(const WTF::PassRefPtr<SkImage>& image)
++void OnRequestCanvasDrawListener::sendNewFrame(sk_sp<SkImage> image)
+ {
+     m_frameCaptureRequested = false;
+-    CanvasDrawListener::sendNewFrame(image);
++    CanvasDrawListener::sendNewFrame(std::move(image));
+ }
+ 
+ } // namespace blink
+diff --git a/third_party/WebKit/Source/modules/mediacapturefromelement/OnRequestCanvasDrawListener.h b/third_party/WebKit/Source/modules/mediacapturefromelement/OnRequestCanvasDrawListener.h
+index d84e0242d6e489e4c7c504a17738d0fa0b57a3a4..7d2313e02c871d67093277b1a7e333b65555b236 100644
+--- a/third_party/WebKit/Source/modules/mediacapturefromelement/OnRequestCanvasDrawListener.h
++++ b/third_party/WebKit/Source/modules/mediacapturefromelement/OnRequestCanvasDrawListener.h
+@@ -8,6 +8,7 @@
+ #include "core/html/canvas/CanvasDrawListener.h"
+ #include "platform/heap/Handle.h"
+ #include "public/platform/WebCanvasCaptureHandler.h"
++#include "third_party/skia/include/core/SkRefCnt.h"
+ #include <memory>
+ 
+ namespace blink {
+@@ -17,7 +18,7 @@ class OnRequestCanvasDrawListener final : public GarbageCollectedFinalized<OnReq
+ public:
+     ~OnRequestCanvasDrawListener();
+     static OnRequestCanvasDrawListener* create(std::unique_ptr<WebCanvasCaptureHandler>);
+-    void sendNewFrame(const WTF::PassRefPtr<SkImage>&) override;
++    void sendNewFrame(sk_sp<SkImage>) override;
+ 
+     DEFINE_INLINE_TRACE() {}
+ private:
+diff --git a/third_party/WebKit/Source/modules/mediacapturefromelement/TimedCanvasDrawListener.cpp b/third_party/WebKit/Source/modules/mediacapturefromelement/TimedCanvasDrawListener.cpp
+index d0f120841a638a15723aa09e335984b459e94db9..aa120ace4ab4c6cc4fb95d933e79c18e3f25741a 100644
+--- a/third_party/WebKit/Source/modules/mediacapturefromelement/TimedCanvasDrawListener.cpp
++++ b/third_party/WebKit/Source/modules/mediacapturefromelement/TimedCanvasDrawListener.cpp
+@@ -4,6 +4,7 @@
+ 
+ #include "modules/mediacapturefromelement/TimedCanvasDrawListener.h"
+ 
++#include "third_party/skia/include/core/SkImage.h"
+ #include <memory>
+ 
+ namespace blink {
+@@ -25,10 +26,10 @@ TimedCanvasDrawListener* TimedCanvasDrawListener::create(std::unique_ptr<WebCanv
+     return listener;
+ }
+ 
+-void TimedCanvasDrawListener::sendNewFrame(const WTF::PassRefPtr<SkImage>& image)
++void TimedCanvasDrawListener::sendNewFrame(sk_sp<SkImage> image)
+ {
+     m_frameCaptureRequested = false;
+-    CanvasDrawListener::sendNewFrame(image);
++    CanvasDrawListener::sendNewFrame(std::move(image));
+ }
+ 
+ void TimedCanvasDrawListener::requestFrameTimerFired(TimerBase*)
+diff --git a/third_party/WebKit/Source/modules/mediacapturefromelement/TimedCanvasDrawListener.h b/third_party/WebKit/Source/modules/mediacapturefromelement/TimedCanvasDrawListener.h
+index 638e4fcc4a97f05bc318e486aa2a18775ede3bb9..29a72962af9d4c7a072f0200140ddf5b57066930 100644
+--- a/third_party/WebKit/Source/modules/mediacapturefromelement/TimedCanvasDrawListener.h
++++ b/third_party/WebKit/Source/modules/mediacapturefromelement/TimedCanvasDrawListener.h
+@@ -9,6 +9,7 @@
+ #include "platform/Timer.h"
+ #include "platform/heap/Handle.h"
+ #include "public/platform/WebCanvasCaptureHandler.h"
++#include "third_party/skia/include/core/SkRefCnt.h"
+ #include <memory>
+ 
+ namespace blink {
+@@ -18,7 +19,7 @@ class TimedCanvasDrawListener final : public GarbageCollectedFinalized<TimedCanv
+ public:
+     ~TimedCanvasDrawListener();
+     static TimedCanvasDrawListener* create(std::unique_ptr<WebCanvasCaptureHandler>, double frameRate);
+-    void sendNewFrame(const WTF::PassRefPtr<SkImage>&) override;
++    void sendNewFrame(sk_sp<SkImage>) override;
+ 
+     DEFINE_INLINE_TRACE() {}
+ private:
+diff --git a/third_party/WebKit/Source/modules/offscreencanvas2d/OffscreenCanvasRenderingContext2D.cpp b/third_party/WebKit/Source/modules/offscreencanvas2d/OffscreenCanvasRenderingContext2D.cpp
+index 202212cc1ffdb1fc6624314e2f76e6b1c5b9c310..96b08881b9914554e5263eda267f112f451c59c1 100644
+--- a/third_party/WebKit/Source/modules/offscreencanvas2d/OffscreenCanvasRenderingContext2D.cpp
++++ b/third_party/WebKit/Source/modules/offscreencanvas2d/OffscreenCanvasRenderingContext2D.cpp
+@@ -58,9 +58,9 @@ void OffscreenCanvasRenderingContext2D::setOriginTainted()
+ bool OffscreenCanvasRenderingContext2D::wouldTaintOrigin(CanvasImageSource* source, ExecutionContext* executionContext)
+ {
+     if (executionContext->isWorkerGlobalScope()) {
+-        // Currently, we only support passing in ImageBitmap as source image in
+-        // drawImage() or createPattern() in a OffscreenCanvas2d in worker.
+-        ASSERT(source->isImageBitmap());
++        // We only support passing in ImageBitmap and OffscreenCanvases as source images
++        // in drawImage() or createPattern() in a OffscreenCanvas2d in worker.
++        DCHECK(source->isImageBitmap() || source->isOffscreenCanvas());
+     }
+ 
+     return CanvasRenderingContext::wouldTaintOrigin(source, executionContext->getSecurityOrigin());
+@@ -118,15 +118,24 @@ ImageBitmap* OffscreenCanvasRenderingContext2D::transferToImageBitmap(ExceptionS
+ {
+     if (!imageBuffer())
+         return nullptr;
+-    RefPtr<SkImage> skImage = m_imageBuffer->newSkImageSnapshot(PreferAcceleration, SnapshotReasonTransferToImageBitmap);
++    sk_sp<SkImage> skImage = m_imageBuffer->newSkImageSnapshot(PreferAcceleration, SnapshotReasonTransferToImageBitmap);
+     DCHECK(isMainThread() || !skImage->isTextureBacked()); // Acceleration not yet supported in Workers
+-    RefPtr<StaticBitmapImage> image = StaticBitmapImage::create(skImage.release());
++    RefPtr<StaticBitmapImage> image = StaticBitmapImage::create(std::move(skImage));
+     image->setOriginClean(this->originClean());
+     m_imageBuffer.reset(); // "Transfer" means no retained buffer
+     m_needsMatrixClipRestore = true;
+     return ImageBitmap::create(image.release());
+ }
+ 
++PassRefPtr<Image> OffscreenCanvasRenderingContext2D::getImage(SnapshotReason reason) const
++{
++    if (!imageBuffer())
++        return nullptr;
++    sk_sp<SkImage> skImage = m_imageBuffer->newSkImageSnapshot(PreferAcceleration, reason);
++    RefPtr<StaticBitmapImage> image = StaticBitmapImage::create(std::move(skImage));
++    return image;
++}
++
+ void OffscreenCanvasRenderingContext2D::setOffscreenCanvasGetContextResult(OffscreenRenderingContext& result)
+ {
+     result.setOffscreenCanvasRenderingContext2D(this);
+diff --git a/third_party/WebKit/Source/modules/offscreencanvas2d/OffscreenCanvasRenderingContext2D.h b/third_party/WebKit/Source/modules/offscreencanvas2d/OffscreenCanvasRenderingContext2D.h
+index 48ac13399b15b1ffe924831d081cf884913e34b1..4ade1b827196cffc7fc04f9ea5b78d4f4ba70a7e 100644
+--- a/third_party/WebKit/Source/modules/offscreencanvas2d/OffscreenCanvasRenderingContext2D.h
++++ b/third_party/WebKit/Source/modules/offscreencanvas2d/OffscreenCanvasRenderingContext2D.h
+@@ -42,6 +42,7 @@ public:
+     void stop() final { ASSERT_NOT_REACHED(); }
+     void setCanvasGetContextResult(RenderingContext&) final {}
+     void clearRect(double x, double y, double width, double height) override { BaseRenderingContext2D::clearRect(x, y, width, height); }
++    PassRefPtr<Image> getImage(SnapshotReason) const final;
+ 
+     // BaseRenderingContext2D implementation
+     bool originClean() const final;
+diff --git a/third_party/WebKit/Source/modules/webgl/WebGLRenderingContextBase.cpp b/third_party/WebKit/Source/modules/webgl/WebGLRenderingContextBase.cpp
+index 597217d7f052d8c319099a8631d94493b8b438c2..8d86b7565bb630168c65ec4edd19c3a99e457a2d 100644
+--- a/third_party/WebKit/Source/modules/webgl/WebGLRenderingContextBase.cpp
++++ b/third_party/WebKit/Source/modules/webgl/WebGLRenderingContextBase.cpp
+@@ -649,6 +649,27 @@ ImageBitmap* WebGLRenderingContextBase::transferToImageBitmapBase()
+     return ImageBitmap::create(drawingBuffer()->transferToStaticBitmapImage());
+ }
+ 
++PassRefPtr<Image> WebGLRenderingContextBase::getImage(SnapshotReason reason) const
++{
++    if (!drawingBuffer())
++        return nullptr;
++
++    drawingBuffer()->commit();
++    IntSize size = clampedCanvasSize();
++    OpacityMode opacityMode = creationAttributes().hasAlpha() ? NonOpaque : Opaque;
++    std::unique_ptr<AcceleratedImageBufferSurface> surface = wrapUnique(new AcceleratedImageBufferSurface(size, opacityMode));
++    if (!surface->isValid())
++        return nullptr;
++    std::unique_ptr<ImageBuffer> buffer = ImageBuffer::create(std::move(surface));
++    if (!buffer->copyRenderingResultsFromDrawingBuffer(drawingBuffer(), BackBuffer)) {
++        // copyRenderingResultsFromDrawingBuffer is expected to always succeed because we've
++        // explicitly created an Accelerated surface and have already validated it.
++        NOTREACHED();
++        return nullptr;
++    }
++    return buffer->newImageSnapshot(PreferAcceleration, reason);
++}
++
+ namespace {
+ 
+ // ES2 enums
+@@ -4523,7 +4544,7 @@ void WebGLRenderingContextBase::texImageHelperImageBitmap(TexImageFunctionID fun
+         }
+         return;
+     }
+-    RefPtr<SkImage> skImage = bitmap->bitmapImage()->imageForCurrentFrame();
++    sk_sp<SkImage> skImage = bitmap->bitmapImage()->imageForCurrentFrame();
+     SkPixmap pixmap;
+     uint8_t* pixelDataPtr = nullptr;
+     RefPtr<Uint8Array> pixelData;
+@@ -6301,7 +6322,7 @@ void WebGLRenderingContextBase::enableOrDisable(GLenum capability, bool enable)
+         contextGL()->Disable(capability);
+ }
+ 
+-IntSize WebGLRenderingContextBase::clampedCanvasSize()
++IntSize WebGLRenderingContextBase::clampedCanvasSize() const
+ {
+     int width, height;
+     if (canvas()) {
+diff --git a/third_party/WebKit/Source/modules/webgl/WebGLRenderingContextBase.h b/third_party/WebKit/Source/modules/webgl/WebGLRenderingContextBase.h
+index f9b56d45bb4895fba3faae25d84ce0ceb075a9ad..ceb0d96bfbc135f643396a683d45f63b45593257 100644
+--- a/third_party/WebKit/Source/modules/webgl/WebGLRenderingContextBase.h
++++ b/third_party/WebKit/Source/modules/webgl/WebGLRenderingContextBase.h
+@@ -412,6 +412,7 @@ public:
+         DECLARE_TRACE();
+     };
+ 
++    PassRefPtr<Image> getImage(SnapshotReason) const override;
+     void setFilterQuality(SkFilterQuality) override;
+     bool isWebGL2OrHigher() { return version() >= 2; }
+ 
+@@ -1037,7 +1038,7 @@ protected:
+     void enableOrDisable(GLenum capability, bool enable);
+ 
+     // Clamp the width and height to GL_MAX_VIEWPORT_DIMS.
+-    IntSize clampedCanvasSize();
++    IntSize clampedCanvasSize() const;
+ 
+     // First time called, if EXT_draw_buffers is supported, query the value; otherwise return 0.
+     // Later, return the cached value.
 diff --git a/third_party/WebKit/Source/platform/BUILD.gn b/third_party/WebKit/Source/platform/BUILD.gn
 index ce25028fe74fa15fe3f9a24dd4188a6407dc7602..fa828ce95c5d4c220355f4cfca8a71e207e3303c 100644
 --- a/third_party/WebKit/Source/platform/BUILD.gn
@@ -2365,6 +4147,3793 @@ index ce25028fe74fa15fe3f9a24dd4188a6407dc7602..fa828ce95c5d4c220355f4cfca8a71e2
  }
  
  # Inspector protocol
+diff --git a/third_party/WebKit/Source/platform/CrossThreadCopier.h b/third_party/WebKit/Source/platform/CrossThreadCopier.h
+index c730cf44540aa83645d858a677dfe4ab4e2ab782..6592e6e4f57e45e89d579b19c45275f2cbe54ff5 100644
+--- a/third_party/WebKit/Source/platform/CrossThreadCopier.h
++++ b/third_party/WebKit/Source/platform/CrossThreadCopier.h
+@@ -32,6 +32,7 @@
+ #define CrossThreadCopier_h
+ 
+ #include "platform/PlatformExport.h"
++#include "third_party/skia/include/core/SkRefCnt.h"
+ #include "wtf/Assertions.h"
+ #include "wtf/Forward.h"
+ #include "wtf/Functional.h" // FunctionThreadAffinity
+@@ -91,12 +92,17 @@ struct CrossThreadCopier : public CrossThreadCopierBase<T, std::is_arithmetic<T>
+ template <typename T>
+ struct CrossThreadCopier<PassRefPtr<T>> : public CrossThreadCopierPassThrough<PassRefPtr<T>> {
+     STATIC_ONLY(CrossThreadCopier);
+-    static_assert(WTF::IsSubclassOfTemplate<T, ThreadSafeRefCounted>::value || std::is_base_of<SkRefCnt, T>::value, "PassRefPtr<T> can be passed across threads only if T is ThreadSafeRefCounted or SkRefCnt.");
++    static_assert(WTF::IsSubclassOfTemplate<T, ThreadSafeRefCounted>::value, "PassRefPtr<T> can be passed across threads only if T is ThreadSafeRefCounted.");
+ };
+ template <typename T>
+ struct CrossThreadCopier<RefPtr<T>> : public CrossThreadCopierPassThrough<RefPtr<T>> {
+     STATIC_ONLY(CrossThreadCopier);
+-    static_assert(WTF::IsSubclassOfTemplate<T, ThreadSafeRefCounted>::value || std::is_base_of<SkRefCnt, T>::value, "RefPtr<T> can be passed across threads only if T is ThreadSafeRefCounted or SkRefCnt.");
++    static_assert(WTF::IsSubclassOfTemplate<T, ThreadSafeRefCounted>::value, "RefPtr<T> can be passed across threads only if T is ThreadSafeRefCounted.");
++};
++template <typename T>
++struct CrossThreadCopier<sk_sp<T>> : public CrossThreadCopierPassThrough<sk_sp<T>> {
++    STATIC_ONLY(CrossThreadCopier);
++    static_assert(std::is_base_of<SkRefCnt, T>::value, "sk_sp<T> can be passed across threads only if T is SkRefCnt.");
+ };
+ 
+ // nullptr_t can be passed through without any changes.
+diff --git a/third_party/WebKit/Source/platform/DragImage.cpp b/third_party/WebKit/Source/platform/DragImage.cpp
+index e1b11d007220e00f0f9f89299123c774ea2a4e9b..93726fe852eba917efa24cb21e3bbd3e42fb69cb 100644
+--- a/third_party/WebKit/Source/platform/DragImage.cpp
++++ b/third_party/WebKit/Source/platform/DragImage.cpp
+@@ -73,7 +73,7 @@ const float kDragLinkUrlFontSize = 10;
+ 
+ } // anonymous namespace
+ 
+-PassRefPtr<SkImage> DragImage::resizeAndOrientImage(PassRefPtr<SkImage> image, ImageOrientation orientation,
++sk_sp<SkImage> DragImage::resizeAndOrientImage(sk_sp<SkImage> image, ImageOrientation orientation,
+     FloatSize imageScale, float opacity, InterpolationQuality interpolationQuality)
+ {
+     IntSize size(image->width(), image->height());
+@@ -108,9 +108,9 @@ PassRefPtr<SkImage> DragImage::resizeAndOrientImage(PassRefPtr<SkImage> image, I
+ 
+     SkCanvas* canvas = surface->getCanvas();
+     canvas->concat(affineTransformToSkMatrix(transform));
+-    canvas->drawImage(image.get(), 0, 0, &paint);
++    canvas->drawImage(image, 0, 0, &paint);
+ 
+-    return fromSkSp(surface->makeImageSnapshot());
++    return surface->makeImageSnapshot();
+ }
+ 
+ FloatSize DragImage::clampedImageScale(const IntSize& imageSize, const IntSize& size,
+@@ -138,7 +138,7 @@ std::unique_ptr<DragImage> DragImage::create(Image* image,
+     if (!image)
+         return nullptr;
+ 
+-    RefPtr<SkImage> skImage = image->imageForCurrentFrame();
++    sk_sp<SkImage> skImage = image->imageForCurrentFrame();
+     if (!skImage)
+         return nullptr;
+ 
+@@ -147,8 +147,8 @@ std::unique_ptr<DragImage> DragImage::create(Image* image,
+         orientation = toBitmapImage(image)->currentFrameOrientation();
+ 
+     SkBitmap bm;
+-    RefPtr<SkImage> resizedImage =
+-        resizeAndOrientImage(skImage.release(), orientation, imageScale, opacity, interpolationQuality);
++    sk_sp<SkImage> resizedImage =
++        resizeAndOrientImage(std::move(skImage), orientation, imageScale, opacity, interpolationQuality);
+     if (!resizedImage || !resizedImage->asLegacyBitmap(&bm, SkImage::kRO_LegacyBitmapMode))
+         return nullptr;
+ 
+diff --git a/third_party/WebKit/Source/platform/DragImage.h b/third_party/WebKit/Source/platform/DragImage.h
+index 9fd422c758cec7f39a006d5f0e99c59712e05ae1..b254cd5dc7760cdf5c243639b3931b7bb79920ea 100644
+--- a/third_party/WebKit/Source/platform/DragImage.h
++++ b/third_party/WebKit/Source/platform/DragImage.h
+@@ -32,6 +32,7 @@
+ #include "platform/graphics/ImageOrientation.h"
+ #include "platform/graphics/paint/DisplayItemClient.h"
+ #include "third_party/skia/include/core/SkBitmap.h"
++#include "third_party/skia/include/core/SkRefCnt.h"
+ #include "wtf/Allocator.h"
+ #include "wtf/Forward.h"
+ #include <memory>
+@@ -64,7 +65,7 @@ public:
+ 
+     void scale(float scaleX, float scaleY);
+ 
+-    static PassRefPtr<SkImage> resizeAndOrientImage(PassRefPtr<SkImage>, ImageOrientation, FloatSize imageScale = FloatSize(1, 1), float opacity = 1.0, InterpolationQuality = InterpolationNone);
++    static sk_sp<SkImage> resizeAndOrientImage(sk_sp<SkImage>, ImageOrientation, FloatSize imageScale = FloatSize(1, 1), float opacity = 1.0, InterpolationQuality = InterpolationNone);
+ 
+ private:
+     DragImage(const SkBitmap&, float resolutionScale, InterpolationQuality);
+diff --git a/third_party/WebKit/Source/platform/DragImageTest.cpp b/third_party/WebKit/Source/platform/DragImageTest.cpp
+index d8f295e92f67fa371b98d318ebbc5f8f474e0330..6f283c92252f6ddd99f2e9d88f1928b35dff1b15 100644
+--- a/third_party/WebKit/Source/platform/DragImageTest.cpp
++++ b/third_party/WebKit/Source/platform/DragImageTest.cpp
+@@ -51,7 +51,7 @@ namespace blink {
+ 
+ class TestImage : public Image {
+ public:
+-    static PassRefPtr<TestImage> create(PassRefPtr<SkImage> image)
++    static PassRefPtr<TestImage> create(sk_sp<SkImage> image)
+     {
+         return adoptRef(new TestImage(image));
+     }
+@@ -68,7 +68,7 @@ public:
+         return IntSize(m_image->width(), m_image->height());
+     }
+ 
+-    PassRefPtr<SkImage> imageForCurrentFrame() override
++    sk_sp<SkImage> imageForCurrentFrame() override
+     {
+         return m_image;
+     }
+@@ -89,7 +89,7 @@ public:
+     }
+ 
+ private:
+-    explicit TestImage(PassRefPtr<SkImage> image)
++    explicit TestImage(sk_sp<SkImage> image)
+         : m_image(image)
+     {
+     }
+@@ -102,7 +102,7 @@ private:
+             return;
+ 
+         surface->getCanvas()->clear(SK_ColorTRANSPARENT);
+-        m_image = fromSkSp(surface->makeImageSnapshot());
++        m_image = surface->makeImageSnapshot();
+     }
+ 
+     static sk_sp<SkSurface> createSkSurface(IntSize size)
+@@ -110,7 +110,7 @@ private:
+         return SkSurface::MakeRaster(SkImageInfo::MakeN32(size.width(), size.height(), kPremul_SkAlphaType));
+     }
+ 
+-    RefPtr<SkImage> m_image;
++    sk_sp<SkImage> m_image;
+ };
+ 
+ TEST(DragImageTest, NullHandling)
+@@ -183,7 +183,7 @@ TEST(DragImageTest, InvalidRotatedBitmapImage)
+     // Create a BitmapImage which will fail to produce pixels, and hence not
+     // draw.
+     SkImageInfo info = SkImageInfo::MakeN32Premul(100, 100);
+-    RefPtr<SkPixelRef> pixelRef = adoptRef(new InvalidPixelRef(info));
++    sk_sp<SkPixelRef> pixelRef(new InvalidPixelRef(info));
+     SkBitmap invalidBitmap;
+     invalidBitmap.setInfo(info);
+     invalidBitmap.setPixelRef(pixelRef.get());
+@@ -221,7 +221,7 @@ TEST(DragImageTest, InterpolationNone)
+         testBitmap.eraseArea(SkIRect::MakeXYWH(1, 1, 1, 1), 0xFFFFFFFF);
+     }
+ 
+-    RefPtr<TestImage> testImage = TestImage::create(fromSkSp(SkImage::MakeFromBitmap(testBitmap)));
++    RefPtr<TestImage> testImage = TestImage::create(SkImage::MakeFromBitmap(testBitmap));
+     std::unique_ptr<DragImage> dragImage = DragImage::create(testImage.get(), DoNotRespectImageOrientation, 1, InterpolationNone);
+     ASSERT_TRUE(dragImage);
+     dragImage->scale(2, 2);
+diff --git a/third_party/WebKit/Source/platform/PODFreeListArenaTest.cpp b/third_party/WebKit/Source/platform/PODFreeListArenaTest.cpp
+index 5624d0454fb3ae3c3b28748093c01582e637714c..4117ce65a61b8f5cc1b995c5f2a99129fa9f3733 100644
+--- a/third_party/WebKit/Source/platform/PODFreeListArenaTest.cpp
++++ b/third_party/WebKit/Source/platform/PODFreeListArenaTest.cpp
+@@ -59,7 +59,7 @@ struct TestClass2 {
+ 
+ class PODFreeListArenaTest : public testing::Test {
+ protected:
+-    int getFreeListSize(const PassRefPtr<PODFreeListArena<TestClass1>> arena) const
++    int getFreeListSize(PassRefPtr<PODFreeListArena<TestClass1>> arena) const
+     {
+         return arena->getFreeListSizeForTesting();
+     }
+diff --git a/third_party/WebKit/Source/platform/audio/AudioDestination.cpp b/third_party/WebKit/Source/platform/audio/AudioDestination.cpp
+index 145baa8b1b0396b055be770e83030af229c93c1a..f8f27dda9d98bc9b2b18ed0d7e69812aba3dd691 100644
+--- a/third_party/WebKit/Source/platform/audio/AudioDestination.cpp
++++ b/third_party/WebKit/Source/platform/audio/AudioDestination.cpp
+@@ -31,6 +31,7 @@
+ #include "platform/Histogram.h"
+ #include "platform/audio/AudioFIFO.h"
+ #include "platform/audio/AudioPullFIFO.h"
++#include "platform/weborigin/SecurityOrigin.h"
+ #include "public/platform/Platform.h"
+ #include "public/platform/WebSecurityOrigin.h"
+ #include "wtf/PtrUtil.h"
+@@ -45,12 +46,12 @@ const unsigned renderBufferSize = 128;
+ const size_t fifoSize = 8192;
+ 
+ // Factory method: Chromium-implementation
+-std::unique_ptr<AudioDestination> AudioDestination::create(AudioIOCallback& callback, const String& inputDeviceId, unsigned numberOfInputChannels, unsigned numberOfOutputChannels, float sampleRate, const PassRefPtr<SecurityOrigin>& securityOrigin)
++std::unique_ptr<AudioDestination> AudioDestination::create(AudioIOCallback& callback, const String& inputDeviceId, unsigned numberOfInputChannels, unsigned numberOfOutputChannels, float sampleRate, PassRefPtr<SecurityOrigin> securityOrigin)
+ {
+     return wrapUnique(new AudioDestination(callback, inputDeviceId, numberOfInputChannels, numberOfOutputChannels, sampleRate, securityOrigin));
+ }
+ 
+-AudioDestination::AudioDestination(AudioIOCallback& callback, const String& inputDeviceId, unsigned numberOfInputChannels, unsigned numberOfOutputChannels, float sampleRate, const PassRefPtr<SecurityOrigin>& securityOrigin)
++AudioDestination::AudioDestination(AudioIOCallback& callback, const String& inputDeviceId, unsigned numberOfInputChannels, unsigned numberOfOutputChannels, float sampleRate, PassRefPtr<SecurityOrigin> securityOrigin)
+     : m_callback(callback)
+     , m_numberOfOutputChannels(numberOfOutputChannels)
+     , m_inputBus(AudioBus::create(numberOfInputChannels, renderBufferSize))
+@@ -189,4 +190,3 @@ void AudioDestination::provideInput(AudioBus* bus, size_t framesToProcess)
+ }
+ 
+ } // namespace blink
+-
+diff --git a/third_party/WebKit/Source/platform/audio/AudioDestination.h b/third_party/WebKit/Source/platform/audio/AudioDestination.h
+index 14c8f916971876bea8ac766b2291c643ee585af9..c449f7cc6abff8e0111e1339f9898fd11cfc174c 100644
+--- a/third_party/WebKit/Source/platform/audio/AudioDestination.h
++++ b/third_party/WebKit/Source/platform/audio/AudioDestination.h
+@@ -36,6 +36,7 @@
+ #include "public/platform/WebVector.h"
+ #include "wtf/Allocator.h"
+ #include "wtf/Noncopyable.h"
++#include "wtf/PassRefPtr.h"
+ #include "wtf/text/WTFString.h"
+ #include <memory>
+ 
+@@ -51,12 +52,12 @@ class PLATFORM_EXPORT AudioDestination : public WebAudioDevice::RenderCallback,
+     USING_FAST_MALLOC(AudioDestination);
+     WTF_MAKE_NONCOPYABLE(AudioDestination);
+ public:
+-    AudioDestination(AudioIOCallback&, const String& inputDeviceId, unsigned numberOfInputChannels, unsigned numberOfOutputChannels, float sampleRate, const PassRefPtr<SecurityOrigin>&);
++    AudioDestination(AudioIOCallback&, const String& inputDeviceId, unsigned numberOfInputChannels, unsigned numberOfOutputChannels, float sampleRate, PassRefPtr<SecurityOrigin>);
+     ~AudioDestination() override;
+ 
+     // Pass in (numberOfInputChannels > 0) if live/local audio input is desired.
+     // Port-specific device identification information for live/local input streams can be passed in the inputDeviceId.
+-    static std::unique_ptr<AudioDestination> create(AudioIOCallback&, const String& inputDeviceId, unsigned numberOfInputChannels, unsigned numberOfOutputChannels, float sampleRate, const PassRefPtr<SecurityOrigin>&);
++    static std::unique_ptr<AudioDestination> create(AudioIOCallback&, const String& inputDeviceId, unsigned numberOfInputChannels, unsigned numberOfOutputChannels, float sampleRate, PassRefPtr<SecurityOrigin>);
+ 
+     virtual void start();
+     virtual void stop();
+diff --git a/third_party/WebKit/Source/platform/exported/WebCryptoResult.cpp b/third_party/WebKit/Source/platform/exported/WebCryptoResult.cpp
+index ec37924c56de79ee415a6a95443d0dce7fa07fed..526c72729eea58a62eba720ec8066df3a743bccf 100644
+--- a/third_party/WebKit/Source/platform/exported/WebCryptoResult.cpp
++++ b/third_party/WebKit/Source/platform/exported/WebCryptoResult.cpp
+@@ -85,7 +85,7 @@ bool WebCryptoResult::cancelled() const
+     return m_cancel->cancelled();
+ }
+ 
+-WebCryptoResult::WebCryptoResult(CryptoResult* impl, const PassRefPtr<CryptoResultCancel>& cancel)
++WebCryptoResult::WebCryptoResult(CryptoResult* impl, PassRefPtr<CryptoResultCancel> cancel)
+     : m_impl(impl)
+     , m_cancel(cancel)
+ {
+diff --git a/third_party/WebKit/Source/platform/exported/WebData.cpp b/third_party/WebKit/Source/platform/exported/WebData.cpp
+index b29b83e6410a9f00c829a60e0169d2127fa21b7e..9fc90b3e34ccfcc42764d1084bae5bffc3d10646 100644
+--- a/third_party/WebKit/Source/platform/exported/WebData.cpp
++++ b/third_party/WebKit/Source/platform/exported/WebData.cpp
+@@ -63,12 +63,12 @@ const char* WebData::data() const
+     return m_private->data();
+ }
+ 
+-WebData::WebData(const PassRefPtr<SharedBuffer>& buffer)
++WebData::WebData(PassRefPtr<SharedBuffer> buffer)
+     : m_private(buffer)
+ {
+ }
+ 
+-WebData& WebData::operator=(const PassRefPtr<SharedBuffer>& buffer)
++WebData& WebData::operator=(PassRefPtr<SharedBuffer> buffer)
+ {
+     m_private = buffer;
+     return *this;
+diff --git a/third_party/WebKit/Source/platform/exported/WebHTTPBody.cpp b/third_party/WebKit/Source/platform/exported/WebHTTPBody.cpp
+index 655de7c92c0306e727926ef385841b32417d61fc..4d833937694003f2237cf901d268971f77291d34 100644
+--- a/third_party/WebKit/Source/platform/exported/WebHTTPBody.cpp
++++ b/third_party/WebKit/Source/platform/exported/WebHTTPBody.cpp
+@@ -165,12 +165,12 @@ void WebHTTPBody::setContainsPasswordData(bool containsPasswordData)
+     m_private->setContainsPasswordData(containsPasswordData);
+ }
+ 
+-WebHTTPBody::WebHTTPBody(const PassRefPtr<EncodedFormData>& data)
++WebHTTPBody::WebHTTPBody(PassRefPtr<EncodedFormData> data)
+     : m_private(static_cast<WebHTTPBodyPrivate*>(data.leakRef()))
+ {
+ }
+ 
+-WebHTTPBody& WebHTTPBody::operator=(const PassRefPtr<EncodedFormData>& data)
++WebHTTPBody& WebHTTPBody::operator=(PassRefPtr<EncodedFormData> data)
+ {
+     assign(static_cast<WebHTTPBodyPrivate*>(data.leakRef()));
+     return *this;
+diff --git a/third_party/WebKit/Source/platform/exported/WebImage.cpp b/third_party/WebKit/Source/platform/exported/WebImage.cpp
+index 202e5f227fb1c9054e4957fa78904638bac20a68..685cac9917583724e384850fc009949979fee865 100644
+--- a/third_party/WebKit/Source/platform/exported/WebImage.cpp
++++ b/third_party/WebKit/Source/platform/exported/WebImage.cpp
+@@ -75,10 +75,7 @@ WebImage WebImage::fromData(const WebData& data, const WebSize& desiredSize)
+     }
+ 
+     ImageFrame* frame = decoder->frameBufferAtIndex(index);
+-    if (!frame)
+-        return WebImage();
+-
+-    return WebImage(frame->bitmap());
++    return (frame && !decoder->failed()) ? WebImage(frame->bitmap()) : WebImage();
+ }
+ 
+ WebVector<WebImage> WebImage::framesFromData(const WebData& data)
+@@ -108,8 +105,8 @@ WebVector<WebImage> WebImage::framesFromData(const WebData& data)
+         if (!frame)
+             continue;
+ 
+-        const SkBitmap& bitmap = frame->bitmap();
+-        if (!bitmap.isNull() && bitmap.isImmutable())
++        SkBitmap bitmap = frame->bitmap();
++        if (!bitmap.isNull() && frame->getStatus() == ImageFrame::FrameComplete)
+             frames.append(WebImage(bitmap));
+     }
+ 
+@@ -136,12 +133,12 @@ WebSize WebImage::size() const
+     return WebSize(m_bitmap.width(), m_bitmap.height());
+ }
+ 
+-WebImage::WebImage(const PassRefPtr<Image>& image)
++WebImage::WebImage(PassRefPtr<Image> image)
+ {
+     if (!image)
+         return;
+ 
+-    if (RefPtr<SkImage> skImage = image->imageForCurrentFrame())
++    if (sk_sp<SkImage> skImage = image->imageForCurrentFrame())
+         skImage->asLegacyBitmap(&m_bitmap, SkImage::kRO_LegacyBitmapMode);
+ }
+ 
+diff --git a/third_party/WebKit/Source/platform/exported/WebSecurityOrigin.cpp b/third_party/WebKit/Source/platform/exported/WebSecurityOrigin.cpp
+index 051232ffcb904bbdd6324b723dc7952d90ef24a9..9ae28a0128791ee52a4b65380d2d9200504f530d 100644
+--- a/third_party/WebKit/Source/platform/exported/WebSecurityOrigin.cpp
++++ b/third_party/WebKit/Source/platform/exported/WebSecurityOrigin.cpp
+@@ -135,12 +135,12 @@ bool WebSecurityOrigin::canAccessPasswordManager() const
+     return m_private->canAccessPasswordManager();
+ }
+ 
+-WebSecurityOrigin::WebSecurityOrigin(const WTF::PassRefPtr<SecurityOrigin>& origin)
++WebSecurityOrigin::WebSecurityOrigin(WTF::PassRefPtr<SecurityOrigin> origin)
+     : m_private(static_cast<WebSecurityOriginPrivate*>(origin.leakRef()))
+ {
+ }
+ 
+-WebSecurityOrigin& WebSecurityOrigin::operator=(const WTF::PassRefPtr<SecurityOrigin>& origin)
++WebSecurityOrigin& WebSecurityOrigin::operator=(WTF::PassRefPtr<SecurityOrigin> origin)
+ {
+     assign(static_cast<WebSecurityOriginPrivate*>(origin.leakRef()));
+     return *this;
+diff --git a/third_party/WebKit/Source/platform/exported/WebThreadSafeData.cpp b/third_party/WebKit/Source/platform/exported/WebThreadSafeData.cpp
+index 0dfe22d737eb0389f62361a02447a2f318d7a371..489f71a149f49f44c5a9922417365eb1aaf4b14b 100644
+--- a/third_party/WebKit/Source/platform/exported/WebThreadSafeData.cpp
++++ b/third_party/WebKit/Source/platform/exported/WebThreadSafeData.cpp
+@@ -64,7 +64,7 @@ const char* WebThreadSafeData::data() const
+     return m_private->data();
+ }
+ 
+-WebThreadSafeData::WebThreadSafeData(const PassRefPtr<RawData>& data)
++WebThreadSafeData::WebThreadSafeData(PassRefPtr<RawData> data)
+     : m_private(data)
+ {
+ }
+@@ -80,7 +80,7 @@ WebThreadSafeData& WebThreadSafeData::operator=(const WebThreadSafeData& other)
+     return *this;
+ }
+ 
+-WebThreadSafeData& WebThreadSafeData::operator=(const PassRefPtr<RawData>& data)
++WebThreadSafeData& WebThreadSafeData::operator=(PassRefPtr<RawData> data)
+ {
+     m_private = data;
+     return *this;
+diff --git a/third_party/WebKit/Source/platform/exported/WebURLLoadTiming.cpp b/third_party/WebKit/Source/platform/exported/WebURLLoadTiming.cpp
+index c74674cfb078eb111c0c0be441378ffc335be91b..d302dcd26190bad2379cb2a699e129fe8d2b7841 100644
+--- a/third_party/WebKit/Source/platform/exported/WebURLLoadTiming.cpp
++++ b/third_party/WebKit/Source/platform/exported/WebURLLoadTiming.cpp
+@@ -210,12 +210,12 @@ void WebURLLoadTiming::setPushEnd(double end)
+     m_private->setPushEnd(end);
+ }
+ 
+-WebURLLoadTiming::WebURLLoadTiming(const PassRefPtr<ResourceLoadTiming>& value)
++WebURLLoadTiming::WebURLLoadTiming(PassRefPtr<ResourceLoadTiming> value)
+     : m_private(value)
+ {
+ }
+ 
+-WebURLLoadTiming& WebURLLoadTiming::operator=(const PassRefPtr<ResourceLoadTiming>& value)
++WebURLLoadTiming& WebURLLoadTiming::operator=(PassRefPtr<ResourceLoadTiming> value)
+ {
+     m_private = value;
+     return *this;
+diff --git a/third_party/WebKit/Source/platform/fonts/Font.cpp b/third_party/WebKit/Source/platform/fonts/Font.cpp
+index 404b2b287ef9a841386e083126f22d8365d7b2ee..74b379a6b8a8358497ea29e3f8aaf880292464b2 100644
+--- a/third_party/WebKit/Source/platform/fonts/Font.cpp
++++ b/third_party/WebKit/Source/platform/fonts/Font.cpp
+@@ -266,7 +266,7 @@ public:
+     bool done() const { return m_index >= m_buffer.size(); }
+     unsigned blobCount() const { return m_blobCount; }
+ 
+-    std::pair<RefPtr<const SkTextBlob>, BlobRotation> next()
++    std::pair<sk_sp<const SkTextBlob>, BlobRotation> next()
+     {
+         ASSERT(!done());
+         const BlobRotation currentRotation = m_rotation;
+@@ -291,7 +291,7 @@ public:
+         }
+ 
+         m_blobCount++;
+-        return std::make_pair(adoptRef(m_builder.build()), currentRotation);
++        return std::make_pair(sk_sp<const SkTextBlob>(m_builder.build()), currentRotation);
+     }
+ 
+ private:
+@@ -350,7 +350,7 @@ void Font::drawGlyphBuffer(SkCanvas* canvas, const SkPaint& paint, const TextRun
+     const GlyphBuffer& glyphBuffer, const FloatPoint& point, float deviceScaleFactor) const
+ {
+     GlyphBufferBloberizer bloberizer(glyphBuffer, this, deviceScaleFactor);
+-    std::pair<RefPtr<const SkTextBlob>, BlobRotation> blob;
++    std::pair<sk_sp<const SkTextBlob>, BlobRotation> blob;
+ 
+     while (!bloberizer.done()) {
+         blob = bloberizer.next();
+@@ -374,7 +374,7 @@ void Font::drawGlyphBuffer(SkCanvas* canvas, const SkPaint& paint, const TextRun
+     //   3) the blob is not upright/rotated
+     if (runInfo.cachedTextBlob && bloberizer.blobCount() == 1 && blob.second == NoRotation) {
+         ASSERT(!*runInfo.cachedTextBlob);
+-        *runInfo.cachedTextBlob = blob.first.release();
++        *runInfo.cachedTextBlob = std::move(blob.first);
+         ASSERT(*runInfo.cachedTextBlob);
+     }
+ }
+diff --git a/third_party/WebKit/Source/platform/fonts/FontCache.cpp b/third_party/WebKit/Source/platform/fonts/FontCache.cpp
+index fbff07e7b59ab6e6a4189874d13888a8e86030d4..fbcdbdbaa88f0df2824ced243ca5cf3e2e928f58 100644
+--- a/third_party/WebKit/Source/platform/fonts/FontCache.cpp
++++ b/third_party/WebKit/Source/platform/fonts/FontCache.cpp
+@@ -76,7 +76,7 @@ typedef HashMap<FallbackListCompositeKey, std::unique_ptr<ShapeCache>, FallbackL
+ static FontPlatformDataCache* gFontPlatformDataCache = nullptr;
+ static FallbackListShaperCache* gFallbackListShaperCache = nullptr;
+ 
+-SkFontMgr* FontCache::s_fontManager = nullptr;
++SkFontMgr* FontCache::s_staticFontManager = nullptr;
+ 
+ #if OS(WIN)
+ bool FontCache::s_antialiasedTextEnabled = false;
+@@ -185,12 +185,12 @@ FontVerticalDataCache& fontVerticalDataCacheInstance()
+     return fontVerticalDataCache;
+ }
+ 
+-void FontCache::setFontManager(const RefPtr<SkFontMgr>& fontManager)
++void FontCache::setFontManager(const sk_sp<SkFontMgr>& fontManager)
+ {
+-    ASSERT(!s_fontManager);
+-    s_fontManager = fontManager.get();
++    DCHECK(!s_staticFontManager);
++    s_staticFontManager = fontManager.get();
+     // Explicitly AddRef since we're going to hold on to the object for the life of the program.
+-    s_fontManager->ref();
++    s_staticFontManager->ref();
+ }
+ 
+ PassRefPtr<OpenTypeVerticalData> FontCache::getVerticalData(const FontFileKey& key, const FontPlatformData& platformData)
+diff --git a/third_party/WebKit/Source/platform/fonts/FontCache.h b/third_party/WebKit/Source/platform/fonts/FontCache.h
+index 3768467b0bbbb201e1a26a445bc138892fa21831..3bd9064bbb6134115004c4fa1e1a3a3ec559df6e 100644
+--- a/third_party/WebKit/Source/platform/fonts/FontCache.h
++++ b/third_party/WebKit/Source/platform/fonts/FontCache.h
+@@ -35,11 +35,11 @@
+ #include "platform/fonts/FontCacheKey.h"
+ #include "platform/fonts/FontFaceCreationParams.h"
+ #include "platform/fonts/FontFallbackPriority.h"
++#include "third_party/skia/include/core/SkRefCnt.h"
+ #include "wtf/Allocator.h"
+ #include "wtf/Forward.h"
+ #include "wtf/HashMap.h"
+ #include "wtf/PassRefPtr.h"
+-#include "wtf/RefPtr.h"
+ #include "wtf/text/CString.h"
+ #include "wtf/text/Unicode.h"
+ #include "wtf/text/WTFString.h"
+@@ -106,7 +106,7 @@ public:
+     void invalidate();
+ 
+     SkFontMgr* fontManager() { return m_fontManager.get(); }
+-    static void setFontManager(const RefPtr<SkFontMgr>&);
++    static void setFontManager(const sk_sp<SkFontMgr>&);
+ 
+ #if OS(WIN)
+     static bool antialiasedTextEnabled() { return s_antialiasedTextEnabled; }
+@@ -177,7 +177,7 @@ private:
+     std::unique_ptr<FontPlatformData> scaleFontPlatformData(const FontPlatformData&, const FontDescription&, const FontFaceCreationParams&, float fontSize);
+ 
+     // Implemented on skia platforms.
+-    PassRefPtr<SkTypeface> createTypeface(const FontDescription&, const FontFaceCreationParams&, CString& name);
++    sk_sp<SkTypeface> createTypeface(const FontDescription&, const FontFaceCreationParams&, CString& name);
+ 
+ #if OS(ANDROID) || OS(LINUX)
+     static AtomicString getFamilyNameForCharacter(SkFontMgr*, UChar32, const FontDescription&, FontFallbackPriority);
+@@ -188,15 +188,15 @@ private:
+     // Don't purge if this count is > 0;
+     int m_purgePreventCount;
+ 
+-    RefPtr<SkFontMgr> m_fontManager;
++    sk_sp<SkFontMgr> m_fontManager;
+ 
+-    static SkFontMgr* s_fontManager;
++    static SkFontMgr* s_staticFontManager;
+ 
+ #if OS(WIN)
+     static bool s_antialiasedTextEnabled;
+     static bool s_lcdTextEnabled;
+     static float s_deviceScaleFactor;
+-    static HashMap<String, RefPtr<SkTypeface>>* s_sideloadedFonts;
++    static HashMap<String, sk_sp<SkTypeface>>* s_sideloadedFonts;
+     // The system font metrics cache.
+     static AtomicString* s_menuFontFamilyName;
+     static int32_t s_menuFontHeight;
+diff --git a/third_party/WebKit/Source/platform/fonts/FontCustomPlatformData.cpp b/third_party/WebKit/Source/platform/fonts/FontCustomPlatformData.cpp
+index c38d495fb0f6809f566002237f28cbc670b137f4..f2b35e6fb1d8eb0bdb60f063097fdfdaaa98912b 100644
+--- a/third_party/WebKit/Source/platform/fonts/FontCustomPlatformData.cpp
++++ b/third_party/WebKit/Source/platform/fonts/FontCustomPlatformData.cpp
+@@ -44,7 +44,7 @@
+ 
+ namespace blink {
+ 
+-FontCustomPlatformData::FontCustomPlatformData(PassRefPtr<SkTypeface> typeface)
++FontCustomPlatformData::FontCustomPlatformData(sk_sp<SkTypeface> typeface)
+     : m_typeface(typeface) { }
+ 
+ FontCustomPlatformData::~FontCustomPlatformData()
+@@ -54,19 +54,19 @@ FontCustomPlatformData::~FontCustomPlatformData()
+ FontPlatformData FontCustomPlatformData::fontPlatformData(float size, bool bold, bool italic, FontOrientation orientation)
+ {
+     ASSERT(m_typeface);
+-    return FontPlatformData(m_typeface.get(), "", size, bold && !m_typeface->isBold(), italic && !m_typeface->isItalic(), orientation);
++    return FontPlatformData(m_typeface, "", size, bold && !m_typeface->isBold(), italic && !m_typeface->isItalic(), orientation);
+ }
+ 
+ std::unique_ptr<FontCustomPlatformData> FontCustomPlatformData::create(SharedBuffer* buffer, String& otsParseMessage)
+ {
+     DCHECK(buffer);
+     WebFontDecoder decoder;
+-    RefPtr<SkTypeface> typeface = decoder.decode(buffer);
++    sk_sp<SkTypeface> typeface = decoder.decode(buffer);
+     if (!typeface) {
+         otsParseMessage = decoder.getErrorString();
+         return nullptr;
+     }
+-    return wrapUnique(new FontCustomPlatformData(typeface.release()));
++    return wrapUnique(new FontCustomPlatformData(std::move(typeface)));
+ }
+ 
+ bool FontCustomPlatformData::supportsFormat(const String& format)
+diff --git a/third_party/WebKit/Source/platform/fonts/FontCustomPlatformData.h b/third_party/WebKit/Source/platform/fonts/FontCustomPlatformData.h
+index 022879b2a7991960bcc17f3e84997ecfa49f1322..0deab5a309d0c71293da792380fec5454e66fd9d 100644
+--- a/third_party/WebKit/Source/platform/fonts/FontCustomPlatformData.h
++++ b/third_party/WebKit/Source/platform/fonts/FontCustomPlatformData.h
+@@ -34,10 +34,10 @@
+ 
+ #include "platform/PlatformExport.h"
+ #include "platform/fonts/FontOrientation.h"
++#include "third_party/skia/include/core/SkRefCnt.h"
+ #include "wtf/Allocator.h"
+ #include "wtf/Forward.h"
+ #include "wtf/Noncopyable.h"
+-#include "wtf/RefPtr.h"
+ #include "wtf/text/WTFString.h"
+ #include <memory>
+ 
+@@ -60,8 +60,8 @@ public:
+     static bool supportsFormat(const String&);
+ 
+ private:
+-    explicit FontCustomPlatformData(PassRefPtr<SkTypeface>);
+-    RefPtr<SkTypeface> m_typeface;
++    explicit FontCustomPlatformData(sk_sp<SkTypeface>);
++    sk_sp<SkTypeface> m_typeface;
+ };
+ 
+ } // namespace blink
+diff --git a/third_party/WebKit/Source/platform/fonts/FontFallbackIterator.cpp b/third_party/WebKit/Source/platform/fonts/FontFallbackIterator.cpp
+index cedbbdc58aa56a339210b253ace4d614523509e2..d9deb15651d6df191b8666c3316cba3a68548d70 100644
+--- a/third_party/WebKit/Source/platform/fonts/FontFallbackIterator.cpp
++++ b/third_party/WebKit/Source/platform/fonts/FontFallbackIterator.cpp
+@@ -62,7 +62,7 @@ void FontFallbackIterator::willUseRange(const AtomicString& family, const FontDa
+     selector->willUseRange(m_fontDescription, family, rangeSet);
+ }
+ 
+-const PassRefPtr<FontDataForRangeSet> FontFallbackIterator::uniqueOrNext(
++PassRefPtr<FontDataForRangeSet> FontFallbackIterator::uniqueOrNext(
+     PassRefPtr<FontDataForRangeSet> candidate,
+     const Vector<UChar32>& hintList) {
+     SkTypeface* candidateTypeface = candidate->fontData()->platformData().typeface();
+@@ -82,7 +82,7 @@ const PassRefPtr<FontDataForRangeSet> FontFallbackIterator::uniqueOrNext(
+ }
+ 
+ 
+-const PassRefPtr<FontDataForRangeSet> FontFallbackIterator::next(const Vector<UChar32>& hintList)
++PassRefPtr<FontDataForRangeSet> FontFallbackIterator::next(const Vector<UChar32>& hintList)
+ {
+     if (m_fallbackStage == OutOfLuck)
+         return adoptRef(new FontDataForRangeSet());
+@@ -181,7 +181,7 @@ const PassRefPtr<FontDataForRangeSet> FontFallbackIterator::next(const Vector<UC
+     return next(hintList);
+ }
+ 
+-const PassRefPtr<SimpleFontData> FontFallbackIterator::fallbackPriorityFont(
++PassRefPtr<SimpleFontData> FontFallbackIterator::fallbackPriorityFont(
+     UChar32 hint)
+ {
+     return FontCache::fontCache()->fallbackFontForCharacter(
+@@ -191,7 +191,7 @@ const PassRefPtr<SimpleFontData> FontFallbackIterator::fallbackPriorityFont(
+         m_fontFallbackPriority);
+ }
+ 
+-const PassRefPtr<SimpleFontData> FontFallbackIterator::uniqueSystemFontForHint(UChar32 hint)
++PassRefPtr<SimpleFontData> FontFallbackIterator::uniqueSystemFontForHint(UChar32 hint)
+ {
+     // When we're asked for a fallback for the same characters again, we give up
+     // because the shaper must have previously tried shaping with the font
+diff --git a/third_party/WebKit/Source/platform/fonts/FontFallbackIterator.h b/third_party/WebKit/Source/platform/fonts/FontFallbackIterator.h
+index 2563a4e4fc07abe308e50bc48b94ddffd220fd08..4b6e4babb98d7cc642f620eddf6819780a6ccbf3 100644
+--- a/third_party/WebKit/Source/platform/fonts/FontFallbackIterator.h
++++ b/third_party/WebKit/Source/platform/fonts/FontFallbackIterator.h
+@@ -35,7 +35,7 @@ public:
+     // Some system fallback APIs (Windows, Android) require a character, or a
+     // portion of the string to be passed.  On Mac and Linux, we get a list of
+     // fonts without passing in characters.
+-    const PassRefPtr<FontDataForRangeSet> next(const Vector<UChar32>& hintList);
++    PassRefPtr<FontDataForRangeSet> next(const Vector<UChar32>& hintList);
+ 
+ private:
+     FontFallbackIterator(const FontDescription&, PassRefPtr<FontFallbackList>,
+@@ -44,10 +44,10 @@ private:
+     bool alreadyLoadingRangeForHintChar(UChar32 hintChar);
+     void willUseRange(const AtomicString& family, const FontDataForRangeSet&);
+ 
+-    const PassRefPtr<FontDataForRangeSet> uniqueOrNext(PassRefPtr<FontDataForRangeSet> candidate, const Vector<UChar32>& hintList);
++    PassRefPtr<FontDataForRangeSet> uniqueOrNext(PassRefPtr<FontDataForRangeSet> candidate, const Vector<UChar32>& hintList);
+ 
+-    const PassRefPtr<SimpleFontData> fallbackPriorityFont(UChar32 hint);
+-    const PassRefPtr<SimpleFontData> uniqueSystemFontForHint(UChar32 hint);
++    PassRefPtr<SimpleFontData> fallbackPriorityFont(UChar32 hint);
++    PassRefPtr<SimpleFontData> uniqueSystemFontForHint(UChar32 hint);
+ 
+     const FontDescription& m_fontDescription;
+     RefPtr<FontFallbackList> m_fontFallbackList;
+diff --git a/third_party/WebKit/Source/platform/fonts/FontPlatformData.cpp b/third_party/WebKit/Source/platform/fonts/FontPlatformData.cpp
+index e6f42cb4a1f9505f00dca43dee4d939932aa7e01..d1c7e0dabf94ea0a226b38300683609eb12505b2 100644
+--- a/third_party/WebKit/Source/platform/fonts/FontPlatformData.cpp
++++ b/third_party/WebKit/Source/platform/fonts/FontPlatformData.cpp
+@@ -131,10 +131,10 @@ FontPlatformData::FontPlatformData(const FontPlatformData& src, float textSize)
+ #endif
+ }
+ 
+-FontPlatformData::FontPlatformData(PassRefPtr<SkTypeface> tf,
++FontPlatformData::FontPlatformData(sk_sp<SkTypeface> tf,
+     const char* family, float textSize, bool syntheticBold,
+     bool syntheticItalic, FontOrientation orientation)
+-    : m_typeface(tf)
++    : m_typeface(std::move(tf))
+ #if !OS(WIN)
+     , m_family(family)
+ #endif
+diff --git a/third_party/WebKit/Source/platform/fonts/FontPlatformData.h b/third_party/WebKit/Source/platform/fonts/FontPlatformData.h
+index faf4636cfcb6d23a6c4163f88897ff05e21e36bd..7f5fa71d951982ecbd9ea3e5df18d679d860ba38 100644
+--- a/third_party/WebKit/Source/platform/fonts/FontPlatformData.h
++++ b/third_party/WebKit/Source/platform/fonts/FontPlatformData.h
+@@ -39,6 +39,7 @@
+ #include "platform/fonts/FontOrientation.h"
+ #include "platform/fonts/SmallCapsIterator.h"
+ #include "platform/fonts/opentype/OpenTypeVerticalData.h"
++#include "third_party/skia/include/core/SkRefCnt.h"
+ #include "wtf/Allocator.h"
+ #include "wtf/Forward.h"
+ #include "wtf/HashTableDeletedValueType.h"
+@@ -87,7 +88,7 @@ public:
+ #if OS(MACOSX)
+     FontPlatformData(NSFont*, float size, bool syntheticBold = false, bool syntheticItalic = false, FontOrientation = FontOrientation::Horizontal);
+ #endif
+-    FontPlatformData(PassRefPtr<SkTypeface>, const char* name, float textSize, bool syntheticBold, bool syntheticItalic, FontOrientation = FontOrientation::Horizontal);
++    FontPlatformData(sk_sp<SkTypeface>, const char* name, float textSize, bool syntheticBold, bool syntheticItalic, FontOrientation = FontOrientation::Horizontal);
+     ~FontPlatformData();
+ 
+ #if OS(MACOSX)
+@@ -141,7 +142,7 @@ private:
+     void querySystemForRenderStyle();
+ #endif
+ 
+-    RefPtr<SkTypeface> m_typeface;
++    sk_sp<SkTypeface> m_typeface;
+ #if !OS(WIN)
+     CString m_family;
+ #endif
+diff --git a/third_party/WebKit/Source/platform/fonts/SegmentedFontData.h b/third_party/WebKit/Source/platform/fonts/SegmentedFontData.h
+index 52bebcf9a8e59b9399f7a8a4a0b13b35008cf04a..3503aec7513ebf706852191d6f6bd55c690ba93a 100644
+--- a/third_party/WebKit/Source/platform/fonts/SegmentedFontData.h
++++ b/third_party/WebKit/Source/platform/fonts/SegmentedFontData.h
+@@ -39,9 +39,9 @@ public:
+ 
+     ~SegmentedFontData() override;
+ 
+-    void appendFace(const PassRefPtr<FontDataForRangeSet> fontDataForRangeSet) { m_faces.append(fontDataForRangeSet); }
++    void appendFace(PassRefPtr<FontDataForRangeSet> fontDataForRangeSet) { m_faces.append(fontDataForRangeSet); }
+     unsigned numFaces() const { return m_faces.size(); }
+-    const PassRefPtr<FontDataForRangeSet> faceAt(unsigned i) const { return m_faces[i]; }
++    PassRefPtr<FontDataForRangeSet> faceAt(unsigned i) const { return m_faces[i]; }
+     bool containsCharacter(UChar32) const;
+ 
+ private:
+diff --git a/third_party/WebKit/Source/platform/fonts/TextBlob.h b/third_party/WebKit/Source/platform/fonts/TextBlob.h
+index d032fdccb02dfa2c3f8e64f4986c11ca1898e568..2ee78ab4410d1d94a2d46ce77cee13e92a693970 100644
+--- a/third_party/WebKit/Source/platform/fonts/TextBlob.h
++++ b/third_party/WebKit/Source/platform/fonts/TextBlob.h
+@@ -6,15 +6,14 @@
+ #define TextBlob_h
+ 
+ #include "third_party/skia/include/core/SkTextBlob.h"
+-#include "wtf/PassRefPtr.h"
+-#include "wtf/RefPtr.h"
+ 
+ namespace blink {
+ 
+ // Holds a (mutable) reference to an immutable SkTextBlob.
+ // Typedefs are used only to insulate core/ from Skia type names.
+-typedef RefPtr<const SkTextBlob> TextBlobPtr;
+-typedef PassRefPtr<const SkTextBlob> PassTextBlobPtr;
++// TODO(fmalita): Need to remove these typedefs - they are obsolete now.
++typedef sk_sp<const SkTextBlob> TextBlobPtr;
++typedef sk_sp<const SkTextBlob> PassTextBlobPtr;
+ 
+ } // namespace blink
+ 
+diff --git a/third_party/WebKit/Source/platform/fonts/WebFontDecoder.cpp b/third_party/WebKit/Source/platform/fonts/WebFontDecoder.cpp
+index ff9ce7c2f3cf223c48a6c656d8f365f26496a3f3..3723461213d12835f291a3171a9fdf7f160a5bb9 100644
+--- a/third_party/WebKit/Source/platform/fonts/WebFontDecoder.cpp
++++ b/third_party/WebKit/Source/platform/fonts/WebFontDecoder.cpp
+@@ -153,7 +153,7 @@ bool WebFontDecoder::supportsFormat(const String& format)
+     return equalIgnoringCase(format, "woff") || equalIgnoringCase(format, "woff2");
+ }
+ 
+-PassRefPtr<SkTypeface> WebFontDecoder::decode(SharedBuffer* buffer)
++sk_sp<SkTypeface> WebFontDecoder::decode(SharedBuffer* buffer)
+ {
+     if (!buffer) {
+         setErrorString("Empty Buffer");
+@@ -190,16 +190,16 @@ PassRefPtr<SkTypeface> WebFontDecoder::decode(SharedBuffer* buffer)
+     sk_sp<SkData> skData = SkData::MakeWithCopy(output.get(), decodedLength);
+     SkMemoryStream* stream = new SkMemoryStream(skData);
+ #if OS(WIN)
+-    RefPtr<SkTypeface> typeface = adoptRef(FontCache::fontCache()->fontManager()->createFromStream(stream));
++    sk_sp<SkTypeface> typeface(FontCache::fontCache()->fontManager()->createFromStream(stream));
+ #else
+-    RefPtr<SkTypeface> typeface = fromSkSp(SkTypeface::MakeFromStream(stream));
++    sk_sp<SkTypeface> typeface = SkTypeface::MakeFromStream(stream);
+ #endif
+     if (!typeface) {
+         setErrorString("Not a valid font data");
+         return nullptr;
+     }
+ 
+-    return typeface.release();
++    return typeface;
+ }
+ 
+ } // namespace blink
+diff --git a/third_party/WebKit/Source/platform/fonts/WebFontDecoder.h b/third_party/WebKit/Source/platform/fonts/WebFontDecoder.h
+index ff2d6a8f0d744bf2cde9961bb72e6d3502991426..6cbef4b2f66763002efc8ceed90ad57d09328e52 100644
+--- a/third_party/WebKit/Source/platform/fonts/WebFontDecoder.h
++++ b/third_party/WebKit/Source/platform/fonts/WebFontDecoder.h
+@@ -31,9 +31,9 @@
+ #ifndef WebFontDecoder_h
+ #define WebFontDecoder_h
+ 
++#include "third_party/skia/include/core/SkRefCnt.h"
+ #include "third_party/skia/include/core/SkTypeface.h"
+ #include "wtf/Allocator.h"
+-#include "wtf/RefPtr.h"
+ #include "wtf/text/WTFString.h"
+ 
+ namespace blink {
+@@ -47,7 +47,7 @@ public:
+     {
+     }
+ 
+-    PassRefPtr<SkTypeface> decode(SharedBuffer*);
++    sk_sp<SkTypeface> decode(SharedBuffer*);
+ 
+     static bool supportsFormat(const String&);
+     String getErrorString() const { return m_otsErrorString; }
+diff --git a/third_party/WebKit/Source/platform/fonts/android/FontCacheAndroid.cpp b/third_party/WebKit/Source/platform/fonts/android/FontCacheAndroid.cpp
+index 50ebfc46caf96bc0a5c5226cc7aa954c132b067f..111d7f01c3d28d4ed003a0f73f692e0a40e807eb 100644
+--- a/third_party/WebKit/Source/platform/fonts/android/FontCacheAndroid.cpp
++++ b/third_party/WebKit/Source/platform/fonts/android/FontCacheAndroid.cpp
+@@ -41,7 +41,7 @@ namespace blink {
+ 
+ PassRefPtr<SimpleFontData> FontCache::fallbackFontForCharacter(const FontDescription& fontDescription, UChar32 c, const SimpleFontData*, FontFallbackPriority fallbackPriority)
+ {
+-    RefPtr<SkFontMgr> fm = adoptRef(SkFontMgr::RefDefault());
++    sk_sp<SkFontMgr> fm(SkFontMgr::RefDefault());
+     AtomicString familyName = getFamilyNameForCharacter(fm.get(), c, fontDescription, fallbackPriority);
+     if (familyName.isEmpty())
+         return getLastResortFallbackFont(fontDescription, DoNotRetain);
+@@ -84,7 +84,7 @@ AtomicString FontCache::getGenericFamilyNameForScript(const AtomicString& family
+         return familyName;
+     }
+ 
+-    RefPtr<SkFontMgr> fm = adoptRef(SkFontMgr::RefDefault());
++    sk_sp<SkFontMgr> fm(SkFontMgr::RefDefault());
+     return getFamilyNameForCharacter(fm.get(), examplerChar, fontDescription, FontFallbackPriority::Text);
+ }
+ 
+diff --git a/third_party/WebKit/Source/platform/fonts/linux/FontCacheLinux.cpp b/third_party/WebKit/Source/platform/fonts/linux/FontCacheLinux.cpp
+index 6b57d8532d45191b5c74c07db724d0feb0661ef1..0f732218ee065a5a3ec95177d4f15faca60f4686 100644
+--- a/third_party/WebKit/Source/platform/fonts/linux/FontCacheLinux.cpp
++++ b/third_party/WebKit/Source/platform/fonts/linux/FontCacheLinux.cpp
+@@ -37,9 +37,9 @@ namespace blink {
+ FontCache::FontCache()
+     : m_purgePreventCount(0)
+ {
+-    if (s_fontManager) {
+-        adopted(s_fontManager);
+-        m_fontManager = s_fontManager;
++    if (s_staticFontManager) {
++        adopted(s_staticFontManager);
++        m_fontManager = sk_ref_sp(s_staticFontManager);
+     } else {
+         m_fontManager = nullptr;
+     }
+diff --git a/third_party/WebKit/Source/platform/fonts/linux/FontPlatformDataLinux.cpp b/third_party/WebKit/Source/platform/fonts/linux/FontPlatformDataLinux.cpp
+index 1f43d31cb87794cf82e6fc7251a7c3dbb67e9b59..b036f708e1454b011267411f2dc3e33eb38df32f 100644
+--- a/third_party/WebKit/Source/platform/fonts/linux/FontPlatformDataLinux.cpp
++++ b/third_party/WebKit/Source/platform/fonts/linux/FontPlatformDataLinux.cpp
+@@ -41,7 +41,7 @@ void FontPlatformData::setupPaint(SkPaint* paint, float deviceScaleFactor, const
+ 
+     const float ts = m_textSize >= 0 ? m_textSize : 12;
+     paint->setTextSize(SkFloatToScalar(ts));
+-    paint->setTypeface(toSkSp(m_typeface));
++    paint->setTypeface(m_typeface);
+     paint->setFakeBoldText(m_syntheticBold);
+     paint->setTextSkewX(m_syntheticItalic ? -SK_Scalar1 / 4 : 0);
+ }
+diff --git a/third_party/WebKit/Source/platform/fonts/mac/FontPlatformDataMac.mm b/third_party/WebKit/Source/platform/fonts/mac/FontPlatformDataMac.mm
+index cb6f5e3e5672f85fb17e632bf94613ef96e306a1..dcc931e9fd98d0a51c749818b95d7b2fc901acca 100644
+--- a/third_party/WebKit/Source/platform/fonts/mac/FontPlatformDataMac.mm
++++ b/third_party/WebKit/Source/platform/fonts/mac/FontPlatformDataMac.mm
+@@ -73,7 +73,7 @@ static CTFontDescriptorRef cascadeToLastResortFontDescriptor()
+     return descriptor;
+ }
+ 
+-static PassRefPtr<SkTypeface> loadFromBrowserProcess(NSFont* nsFont, float textSize)
++static sk_sp<SkTypeface> loadFromBrowserProcess(NSFont* nsFont, float textSize)
+ {
+     // Send cross-process request to load font.
+     WebSandboxSupport* sandboxSupport = Platform::current()->sandboxSupport();
+@@ -94,7 +94,7 @@ static PassRefPtr<SkTypeface> loadFromBrowserProcess(NSFont* nsFont, float textS
+     }
+     RetainPtr<CGFontRef> cgFont(AdoptCF, loadedCgFont);
+     RetainPtr<CTFontRef> ctFont(AdoptCF, CTFontCreateWithGraphicsFont(cgFont.get(), textSize, 0, cascadeToLastResortFontDescriptor()));
+-    PassRefPtr<SkTypeface> returnFont = adoptRef(SkCreateTypefaceFromCTFont(ctFont.get(), cgFont.get()));
++    sk_sp<SkTypeface> returnFont(SkCreateTypefaceFromCTFont(ctFont.get(), cgFont.get()));
+ 
+     if (!returnFont.get())
+         // TODO crbug.com/461279: Make this appear in the inspector console?
+@@ -133,7 +133,7 @@ void FontPlatformData::setupPaint(SkPaint* paint, float, const Font* font) const
+     paint->setEmbeddedBitmapText(false);
+     const float ts = m_textSize >= 0 ? m_textSize : 12;
+     paint->setTextSize(SkFloatToScalar(ts));
+-    paint->setTypeface(toSkSp(m_typeface));
++    paint->setTypeface(m_typeface);
+     paint->setFakeBoldText(m_syntheticBold);
+     paint->setTextSkewX(m_syntheticItalic ? -SK_Scalar1 / 4 : 0);
+     paint->setLCDRenderText(shouldSmoothFonts);
+@@ -155,7 +155,7 @@ FontPlatformData::FontPlatformData(NSFont *nsFont, float size, bool syntheticBol
+ {
+     DCHECK(nsFont);
+     if (canLoadInProcess(nsFont)) {
+-        m_typeface = adoptRef(SkCreateTypefaceFromCTFont(toCTFontRef(nsFont)));
++        m_typeface.reset(SkCreateTypefaceFromCTFont(toCTFontRef(nsFont)));
+     } else {
+         // In process loading fails for cases where third party font manager software
+         // registers fonts in non system locations such as /Library/Fonts
+diff --git a/third_party/WebKit/Source/platform/fonts/skia/FontCacheSkia.cpp b/third_party/WebKit/Source/platform/fonts/skia/FontCacheSkia.cpp
+index a81e5a00987eb9a109709e259eee433fda40018c..d59776ce477e1ac1cb91d22412f3b86404a64f11 100644
+--- a/third_party/WebKit/Source/platform/fonts/skia/FontCacheSkia.cpp
++++ b/third_party/WebKit/Source/platform/fonts/skia/FontCacheSkia.cpp
+@@ -50,13 +50,13 @@
+ #if !OS(WIN) && !OS(ANDROID)
+ #include "SkFontConfigInterface.h"
+ 
+-static PassRefPtr<SkTypeface> typefaceForFontconfigInterfaceIdAndTtcIndex(int fontconfigInterfaceId, int ttcIndex)
++static sk_sp<SkTypeface> typefaceForFontconfigInterfaceIdAndTtcIndex(int fontconfigInterfaceId, int ttcIndex)
+ {
+     SkAutoTUnref<SkFontConfigInterface> fci(SkFontConfigInterface::RefGlobal());
+     SkFontConfigInterface::FontIdentity fontIdentity;
+     fontIdentity.fID = fontconfigInterfaceId;
+     fontIdentity.fTTCIndex = ttcIndex;
+-    return blink::fromSkSp(fci->makeTypeface(fontIdentity));
++    return fci->makeTypeface(fontIdentity);
+ }
+ #endif
+ 
+@@ -91,7 +91,7 @@ AtomicString FontCache::getFamilyNameForCharacter(SkFontMgr* fm, UChar32 c, cons
+     if (fallbackPriority == FontFallbackPriority::EmojiEmoji)
+         bcp47Locales[localeCount++] = kAndroidColorEmojiLocale;
+     SECURITY_DCHECK(localeCount <= kMaxLocales);
+-    RefPtr<SkTypeface> typeface = adoptRef(fm->matchFamilyStyleCharacter(0, SkFontStyle(), bcp47Locales, localeCount, c));
++    sk_sp<SkTypeface> typeface(fm->matchFamilyStyleCharacter(0, SkFontStyle(), bcp47Locales, localeCount, c));
+     if (!typeface)
+         return emptyAtom;
+ 
+@@ -154,13 +154,13 @@ PassRefPtr<SimpleFontData> FontCache::getLastResortFallbackFont(const FontDescri
+     return fontDataFromFontPlatformData(fontPlatformData, shouldRetain);
+ }
+ 
+-PassRefPtr<SkTypeface> FontCache::createTypeface(const FontDescription& fontDescription, const FontFaceCreationParams& creationParams, CString& name)
++sk_sp<SkTypeface> FontCache::createTypeface(const FontDescription& fontDescription, const FontFaceCreationParams& creationParams, CString& name)
+ {
+ #if !OS(WIN) && !OS(ANDROID)
+     if (creationParams.creationType() == CreateFontByFciIdAndTtcIndex) {
+         if (Platform::current()->sandboxSupport())
+             return typefaceForFontconfigInterfaceIdAndTtcIndex(creationParams.fontconfigInterfaceId(), creationParams.ttcIndex());
+-        return fromSkSp(SkTypeface::MakeFromFile(creationParams.filename().data(), creationParams.ttcIndex()));
++        return SkTypeface::MakeFromFile(creationParams.filename().data(), creationParams.ttcIndex());
+     }
+ #endif
+ 
+@@ -176,7 +176,7 @@ PassRefPtr<SkTypeface> FontCache::createTypeface(const FontDescription& fontDesc
+ 
+ #if OS(WIN)
+     if (s_sideloadedFonts) {
+-        HashMap<String, RefPtr<SkTypeface>>::iterator sideloadedFont =
++        HashMap<String, sk_sp<SkTypeface>>::iterator sideloadedFont =
+             s_sideloadedFonts->find(name.data());
+         if (sideloadedFont != s_sideloadedFonts->end())
+             return sideloadedFont->value;
+@@ -189,13 +189,13 @@ PassRefPtr<SkTypeface> FontCache::createTypeface(const FontDescription& fontDesc
+     // call to the default font Manager.
+     // On Windows the font manager is always present.
+     if (m_fontManager)
+-        return adoptRef(m_fontManager->matchFamilyStyle(name.data(), fontDescription.skiaFontStyle()));
++        return sk_sp<SkTypeface>(m_fontManager->matchFamilyStyle(name.data(), fontDescription.skiaFontStyle()));
+ #endif
+ 
+     // FIXME: Use m_fontManager, matchFamilyStyle instead of
+     // legacyCreateTypeface on all platforms.
+-    RefPtr<SkFontMgr> fm = adoptRef(SkFontMgr::RefDefault());
+-    return adoptRef(fm->legacyCreateTypeface(name.data(),
++    sk_sp<SkFontMgr> fm(SkFontMgr::RefDefault());
++    return sk_sp<SkTypeface>(fm->legacyCreateTypeface(name.data(),
+         fontDescription.skiaFontStyle()));
+ }
+ 
+@@ -204,7 +204,7 @@ std::unique_ptr<FontPlatformData> FontCache::createFontPlatformData(const FontDe
+     const FontFaceCreationParams& creationParams, float fontSize)
+ {
+     CString name;
+-    RefPtr<SkTypeface> tf(createTypeface(fontDescription, creationParams, name));
++    sk_sp<SkTypeface> tf = createTypeface(fontDescription, creationParams, name);
+     if (!tf)
+         return nullptr;
+ 
+diff --git a/third_party/WebKit/Source/platform/fonts/win/FontCacheSkiaWin.cpp b/third_party/WebKit/Source/platform/fonts/win/FontCacheSkiaWin.cpp
+index b8e6238cdda2c31b1fc4e6ba22e5a1bdfcfa4aeb..d354cd12a75dbbbb4bc56ae1c9be6afc73679d6f 100644
+--- a/third_party/WebKit/Source/platform/fonts/win/FontCacheSkiaWin.cpp
++++ b/third_party/WebKit/Source/platform/fonts/win/FontCacheSkiaWin.cpp
+@@ -45,7 +45,7 @@
+ 
+ namespace blink {
+ 
+-HashMap<String, RefPtr<SkTypeface>>* FontCache::s_sideloadedFonts = 0;
++HashMap<String, sk_sp<SkTypeface>>* FontCache::s_sideloadedFonts = 0;
+ 
+ // Cached system font metrics.
+ AtomicString* FontCache::s_menuFontFamilyName = 0;
+@@ -70,10 +70,10 @@ int32_t ensureMinimumFontHeightIfNeeded(int32_t fontHeight)
+ void FontCache::addSideloadedFontForTesting(SkTypeface* typeface)
+ {
+     if (!s_sideloadedFonts)
+-        s_sideloadedFonts = new HashMap<String, RefPtr<SkTypeface>>;
++        s_sideloadedFonts = new HashMap<String, sk_sp<SkTypeface>>;
+     SkString name;
+     typeface->getFamilyName(&name);
+-    s_sideloadedFonts->set(name.c_str(), adoptRef(typeface));
++    s_sideloadedFonts->set(name.c_str(), sk_sp<SkTypeface>(typeface));
+ }
+ 
+ // static
+@@ -100,9 +100,9 @@ void FontCache::setStatusFontMetrics(const wchar_t* familyName, int32_t fontHeig
+ FontCache::FontCache()
+     : m_purgePreventCount(0)
+ {
+-    m_fontManager = s_fontManager;
+-    if (!m_fontManager.get())
+-        m_fontManager = adoptRef(SkFontMgr_New_DirectWrite());
++    m_fontManager = sk_ref_sp(s_staticFontManager);
++    if (!m_fontManager)
++        m_fontManager.reset(SkFontMgr_New_DirectWrite());
+     ASSERT(m_fontManager.get());
+ }
+ 
+@@ -360,7 +360,7 @@ std::unique_ptr<FontPlatformData> FontCache::createFontPlatformData(const FontDe
+     ASSERT(creationParams.creationType() == CreateFontByFamily);
+ 
+     CString name;
+-    RefPtr<SkTypeface> tf = createTypeface(fontDescription, creationParams, name);
++    sk_sp<SkTypeface> tf = createTypeface(fontDescription, creationParams, name);
+     // Windows will always give us a valid pointer here, even if the face name
+     // is non-existent. We have to double-check and see if the family name was
+     // really used.
+diff --git a/third_party/WebKit/Source/platform/fonts/win/FontFallbackWin.cpp b/third_party/WebKit/Source/platform/fonts/win/FontFallbackWin.cpp
+index 21dbcbfab0bd528c79b3fcbdf8d30b945d0b8381..6decd579867605f5496fb6276a086d17fa0087bd 100644
+--- a/third_party/WebKit/Source/platform/fonts/win/FontFallbackWin.cpp
++++ b/third_party/WebKit/Source/platform/fonts/win/FontFallbackWin.cpp
+@@ -47,13 +47,10 @@ namespace {
+ static inline bool isFontPresent(const UChar* fontName, SkFontMgr* fontManager)
+ {
+     String family = fontName;
+-    SkTypeface* typeface;
+-    typeface = fontManager->matchFamilyStyle(family.utf8().data(), SkFontStyle());
+-
+-    if (!typeface)
++    sk_sp<SkTypeface> tf(fontManager->matchFamilyStyle(family.utf8().data(), SkFontStyle()));
++    if (!tf)
+         return false;
+ 
+-    RefPtr<SkTypeface> tf = adoptRef(typeface);
+     SkTypeface::LocalizedStrings* actualFamilies = tf->createFamilyNameIterator();
+     bool matchesRequestedFamily = false;
+     SkTypeface::LocalizedString actualFamily;
+diff --git a/third_party/WebKit/Source/platform/fonts/win/FontPlatformDataWin.cpp b/third_party/WebKit/Source/platform/fonts/win/FontPlatformDataWin.cpp
+index 903060cce0922e849330d2d9f8086eb3ab09fbc3..f11ede8c8d489b86f9c1a62eb6f519bf85fdccb1 100644
+--- a/third_party/WebKit/Source/platform/fonts/win/FontPlatformDataWin.cpp
++++ b/third_party/WebKit/Source/platform/fonts/win/FontPlatformDataWin.cpp
+@@ -48,7 +48,7 @@ void FontPlatformData::setupPaint(SkPaint* paint, float, const Font*) const
+ {
+     const float ts = m_textSize >= 0 ? m_textSize : 12;
+     paint->setTextSize(SkFloatToScalar(m_textSize));
+-    paint->setTypeface(toSkSp(m_typeface));
++    paint->setTypeface(m_typeface);
+     paint->setFakeBoldText(m_syntheticBold);
+     paint->setTextSkewX(m_syntheticItalic ? -SK_Scalar1 / 4 : 0);
+ 
+diff --git a/third_party/WebKit/Source/platform/graphics/AcceleratedStaticBitmapImage.cpp b/third_party/WebKit/Source/platform/graphics/AcceleratedStaticBitmapImage.cpp
+index 0ec750ec1b6c1019be6bd2499f8338e5872d67da..c572b79a3a5b4552538ef754a612b11024fea9a7 100644
+--- a/third_party/WebKit/Source/platform/graphics/AcceleratedStaticBitmapImage.cpp
++++ b/third_party/WebKit/Source/platform/graphics/AcceleratedStaticBitmapImage.cpp
+@@ -20,23 +20,23 @@
+ 
+ namespace blink {
+ 
+-PassRefPtr<AcceleratedStaticBitmapImage> AcceleratedStaticBitmapImage::create(PassRefPtr<SkImage> image)
++PassRefPtr<AcceleratedStaticBitmapImage> AcceleratedStaticBitmapImage::create(sk_sp<SkImage> image)
+ {
+-    return adoptRef(new AcceleratedStaticBitmapImage(image));
++    return adoptRef(new AcceleratedStaticBitmapImage(std::move(image)));
+ }
+ 
+-PassRefPtr<AcceleratedStaticBitmapImage> AcceleratedStaticBitmapImage::create(PassRefPtr<SkImage> image, sk_sp<GrContext> grContext, const gpu::Mailbox& mailbox, const gpu::SyncToken& syncToken)
++PassRefPtr<AcceleratedStaticBitmapImage> AcceleratedStaticBitmapImage::create(sk_sp<SkImage> image, sk_sp<GrContext> grContext, const gpu::Mailbox& mailbox, const gpu::SyncToken& syncToken)
+ {
+-    return adoptRef(new AcceleratedStaticBitmapImage(image, std::move(grContext), mailbox, syncToken));
++    return adoptRef(new AcceleratedStaticBitmapImage(std::move(image), std::move(grContext), mailbox, syncToken));
+ }
+ 
+-AcceleratedStaticBitmapImage::AcceleratedStaticBitmapImage(PassRefPtr<SkImage> image)
++AcceleratedStaticBitmapImage::AcceleratedStaticBitmapImage(sk_sp<SkImage> image)
+     : StaticBitmapImage(std::move(image))
+     , m_imageIsForSharedMainThreadContext(true)
+ {
+ }
+ 
+-AcceleratedStaticBitmapImage::AcceleratedStaticBitmapImage(PassRefPtr<SkImage> image, sk_sp<GrContext> grContext, const gpu::Mailbox& mailbox, const gpu::SyncToken& syncToken)
++AcceleratedStaticBitmapImage::AcceleratedStaticBitmapImage(sk_sp<SkImage> image, sk_sp<GrContext> grContext, const gpu::Mailbox& mailbox, const gpu::SyncToken& syncToken)
+     : StaticBitmapImage(std::move(image))
+     , m_imageIsForSharedMainThreadContext(false) // TODO(danakj): Could be true though, caller would know.
+     , m_grContext(std::move(grContext))
+@@ -64,7 +64,7 @@ void AcceleratedStaticBitmapImage::copyToTexture(WebGraphicsContext3DProvider* d
+     destGL->DeleteTextures(1, &sourceTextureId);
+ }
+ 
+-PassRefPtr<SkImage> AcceleratedStaticBitmapImage::imageForCurrentFrame()
++sk_sp<SkImage> AcceleratedStaticBitmapImage::imageForCurrentFrame()
+ {
+     // This must return an SkImage that can be used with the shared main thread context. If |m_image| satisfies that, we are done.
+     if (m_imageIsForSharedMainThreadContext)
+@@ -96,7 +96,7 @@ PassRefPtr<SkImage> AcceleratedStaticBitmapImage::imageForCurrentFrame()
+     backendTexture.fConfig = kSkia8888_GrPixelConfig;
+     backendTexture.fTextureHandle = skia::GrGLTextureInfoToGrBackendObject(textureInfo);
+ 
+-    m_image = fromSkSp(SkImage::MakeFromAdoptedTexture(sharedGrContext, backendTexture));
++    m_image = SkImage::MakeFromAdoptedTexture(sharedGrContext, backendTexture);
+     m_imageIsForSharedMainThreadContext = true;
+     // Can drop the ref on the GrContext since m_image is now backed by a texture from the shared main thread context.
+     m_grContext = nullptr;
+diff --git a/third_party/WebKit/Source/platform/graphics/AcceleratedStaticBitmapImage.h b/third_party/WebKit/Source/platform/graphics/AcceleratedStaticBitmapImage.h
+index a45db448f88088283da39340d67a7ef67803c5fc..aa8b38e9d46e78c4cc772c0f529a1e1d25c3a860 100644
+--- a/third_party/WebKit/Source/platform/graphics/AcceleratedStaticBitmapImage.h
++++ b/third_party/WebKit/Source/platform/graphics/AcceleratedStaticBitmapImage.h
+@@ -9,6 +9,7 @@
+ #include "gpu/command_buffer/common/sync_token.h"
+ #include "platform/geometry/IntSize.h"
+ #include "platform/graphics/StaticBitmapImage.h"
++#include "third_party/skia/include/core/SkRefCnt.h"
+ 
+ #include <memory>
+ 
+@@ -23,20 +24,20 @@ namespace blink {
+ class PLATFORM_EXPORT AcceleratedStaticBitmapImage final : public StaticBitmapImage {
+ public:
+     // SkImage with a texture backing that is assumed to be from the shared main thread context.
+-    static PassRefPtr<AcceleratedStaticBitmapImage> create(PassRefPtr<SkImage>);
++    static PassRefPtr<AcceleratedStaticBitmapImage> create(sk_sp<SkImage>);
+     // Can specify the GrContext that created the texture backing the for the given SkImage. Ideally all callers would use this option.
+     // The |mailbox| is a name for the texture backing the SkImage, allowing other contexts to use the same backing.
+-    static PassRefPtr<AcceleratedStaticBitmapImage> create(PassRefPtr<SkImage>, sk_sp<GrContext>, const gpu::Mailbox&, const gpu::SyncToken&);
++    static PassRefPtr<AcceleratedStaticBitmapImage> create(sk_sp<SkImage>, sk_sp<GrContext>, const gpu::Mailbox&, const gpu::SyncToken&);
+ 
+     ~AcceleratedStaticBitmapImage() override;
+ 
+     // StaticBitmapImage overrides.
+-    PassRefPtr<SkImage> imageForCurrentFrame() override;
++    sk_sp<SkImage> imageForCurrentFrame() override;
+     void copyToTexture(WebGraphicsContext3DProvider*, GLuint destTextureId, GLenum destInternalFormat, GLenum destType, bool flipY) override;
+ 
+ private:
+-    AcceleratedStaticBitmapImage(PassRefPtr<SkImage>);
+-    AcceleratedStaticBitmapImage(PassRefPtr<SkImage>, sk_sp<GrContext>, const gpu::Mailbox&, const gpu::SyncToken&);
++    AcceleratedStaticBitmapImage(sk_sp<SkImage>);
++    AcceleratedStaticBitmapImage(sk_sp<SkImage>, sk_sp<GrContext>, const gpu::Mailbox&, const gpu::SyncToken&);
+ 
+     bool switchStorageToMailbox(WebGraphicsContext3DProvider*);
+     GLuint switchStorageToSkImageForWebGL(WebGraphicsContext3DProvider*);
+diff --git a/third_party/WebKit/Source/platform/graphics/BitmapImage.cpp b/third_party/WebKit/Source/platform/graphics/BitmapImage.cpp
+index 5f37d4cd2ee1163c5a88077deb206819ce34aabe..63aae48e329791a7bd2998ea1170baa8370c6da3 100644
+--- a/third_party/WebKit/Source/platform/graphics/BitmapImage.cpp
++++ b/third_party/WebKit/Source/platform/graphics/BitmapImage.cpp
+@@ -77,7 +77,7 @@ BitmapImage::BitmapImage(const SkBitmap& bitmap, ImageObserver* observer)
+     : Image(observer)
+     , m_size(bitmap.width(), bitmap.height())
+     , m_currentFrame(0)
+-    , m_cachedFrame(fromSkSp(SkImage::MakeFromBitmap(bitmap)))
++    , m_cachedFrame(SkImage::MakeFromBitmap(bitmap))
+     , m_cachedFrameIndex(0)
+     , m_repetitionCount(cAnimationNone)
+     , m_repetitionCountStatus(Unknown)
+@@ -111,7 +111,7 @@ bool BitmapImage::currentFrameHasSingleSecurityOrigin() const
+ 
+ void BitmapImage::destroyDecodedData()
+ {
+-    m_cachedFrame.clear();
++    m_cachedFrame.reset();
+     for (size_t i = 0; i < m_frames.size(); ++i)
+         m_frames[i].clear(true);
+     m_source.clearCacheExceptFrame(kNotFound);
+@@ -138,7 +138,7 @@ size_t BitmapImage::totalFrameBytes()
+     return totalBytes;
+ }
+ 
+-PassRefPtr<SkImage> BitmapImage::decodeAndCacheFrame(size_t index)
++sk_sp<SkImage> BitmapImage::decodeAndCacheFrame(size_t index)
+ {
+     size_t numFrames = frameCount();
+     if (m_frames.size() < numFrames)
+@@ -146,7 +146,7 @@ PassRefPtr<SkImage> BitmapImage::decodeAndCacheFrame(size_t index)
+ 
+     // We are caching frame snapshots.  This is OK even for partially decoded frames,
+     // as they are cleared by dataChanged() when new data arrives.
+-    RefPtr<SkImage> image = m_source.createFrameAtIndex(index);
++    sk_sp<SkImage> image = m_source.createFrameAtIndex(index);
+     m_cachedFrame = image;
+     m_cachedFrameIndex = index;
+ 
+@@ -159,7 +159,7 @@ PassRefPtr<SkImage> BitmapImage::decodeAndCacheFrame(size_t index)
+     m_frames[index].m_frameBytes = m_source.frameBytesAtIndex(index);
+ 
+     notifyMemoryChanged();
+-    return image.release();
++    return image;
+ }
+ 
+ void BitmapImage::updateSize() const
+@@ -234,7 +234,7 @@ Image::SizeAvailability BitmapImage::dataChanged(bool allDataReceived)
+         if (m_frames[i].m_haveMetadata && !m_frames[i].m_isComplete) {
+             m_frames[i].clear(true);
+             if (i == m_cachedFrameIndex)
+-                m_cachedFrame.clear();
++                m_cachedFrame.reset();
+         }
+     }
+ 
+@@ -259,7 +259,7 @@ void BitmapImage::draw(SkCanvas* canvas, const SkPaint& paint, const FloatRect&
+ {
+     TRACE_EVENT0("skia", "BitmapImage::draw");
+ 
+-    RefPtr<SkImage> image = imageForCurrentFrame();
++    sk_sp<SkImage> image = imageForCurrentFrame();
+     if (!image)
+         return; // It's too early and we don't have an image yet.
+ 
+@@ -336,7 +336,7 @@ bool BitmapImage::isSizeAvailable()
+     return m_sizeAvailable;
+ }
+ 
+-PassRefPtr<SkImage> BitmapImage::frameAtIndex(size_t index)
++sk_sp<SkImage> BitmapImage::frameAtIndex(size_t index)
+ {
+     if (index >= frameCount())
+         return nullptr;
+@@ -363,7 +363,7 @@ float BitmapImage::frameDurationAtIndex(size_t index)
+     return m_source.frameDurationAtIndex(index);
+ }
+ 
+-PassRefPtr<SkImage> BitmapImage::imageForCurrentFrame()
++sk_sp<SkImage> BitmapImage::imageForCurrentFrame()
+ {
+     return frameAtIndex(currentFrame());
+ }
+@@ -371,9 +371,9 @@ PassRefPtr<SkImage> BitmapImage::imageForCurrentFrame()
+ PassRefPtr<Image> BitmapImage::imageForDefaultFrame()
+ {
+     if (frameCount() > 1) {
+-        RefPtr<SkImage> firstFrame = frameAtIndex(0);
++        sk_sp<SkImage> firstFrame = frameAtIndex(0);
+         if (firstFrame)
+-            return StaticBitmapImage::create(firstFrame);
++            return StaticBitmapImage::create(std::move(firstFrame));
+     }
+ 
+     return Image::imageForDefaultFrame();
+@@ -414,7 +414,7 @@ bool BitmapImage::currentFrameIsComplete()
+ 
+ bool BitmapImage::currentFrameIsLazyDecoded()
+ {
+-    RefPtr<SkImage> image = frameAtIndex(currentFrame());
++    sk_sp<SkImage> image = frameAtIndex(currentFrame());
+     return image && image->isLazyGenerated();
+ }
+ 
+@@ -552,7 +552,7 @@ void BitmapImage::resetAnimation()
+     m_repetitionsComplete = 0;
+     m_desiredFrameStartTime = 0;
+     m_animationFinished = false;
+-    m_cachedFrame.clear();
++    m_cachedFrame.reset();
+ }
+ 
+ bool BitmapImage::maybeAnimated()
+diff --git a/third_party/WebKit/Source/platform/graphics/BitmapImage.h b/third_party/WebKit/Source/platform/graphics/BitmapImage.h
+index 8dc47dd808fcd8ae4264c09500e0b310ef912a10..0c5088ac3e077832fa7f1be9d1dc4054f45ffb9c 100644
+--- a/third_party/WebKit/Source/platform/graphics/BitmapImage.h
++++ b/third_party/WebKit/Source/platform/graphics/BitmapImage.h
+@@ -37,6 +37,7 @@
+ #include "platform/graphics/ImageOrientation.h"
+ #include "platform/graphics/ImageSource.h"
+ #include "platform/image-decoders/ImageAnimation.h"
++#include "third_party/skia/include/core/SkRefCnt.h"
+ #include "wtf/Forward.h"
+ #include <memory>
+ 
+@@ -78,7 +79,7 @@ public:
+     ImageAnimationPolicy animationPolicy() override { return m_animationPolicy; }
+     void advanceTime(double deltaTimeInSeconds) override;
+ 
+-    PassRefPtr<SkImage> imageForCurrentFrame() override;
++    sk_sp<SkImage> imageForCurrentFrame() override;
+     PassRefPtr<Image> imageForDefaultFrame() override;
+ 
+     bool currentFrameKnownToBeOpaque(MetadataMode = UseCurrentMetadata) override;
+@@ -107,14 +108,14 @@ private:
+     size_t currentFrame() const { return m_currentFrame; }
+     size_t frameCount();
+ 
+-    PassRefPtr<SkImage> frameAtIndex(size_t);
++    sk_sp<SkImage> frameAtIndex(size_t);
+ 
+     bool frameIsCompleteAtIndex(size_t);
+     float frameDurationAtIndex(size_t);
+     bool frameHasAlphaAtIndex(size_t);
+     ImageOrientation frameOrientationAtIndex(size_t);
+ 
+-    PassRefPtr<SkImage> decodeAndCacheFrame(size_t index);
++    sk_sp<SkImage> decodeAndCacheFrame(size_t index);
+     void updateSize() const;
+ 
+     // Returns the total number of bytes allocated for all framebuffers, i.e.
+@@ -170,7 +171,7 @@ private:
+     size_t m_currentFrame; // The index of the current frame of animation.
+     Vector<FrameData, 1> m_frames; // An array of the cached frames of the animation. We have to ref frames to pin them in the cache.
+ 
+-    RefPtr<SkImage> m_cachedFrame; // A cached copy of the most recently-accessed frame.
++    sk_sp<SkImage> m_cachedFrame; // A cached copy of the most recently-accessed frame.
+     size_t m_cachedFrameIndex; // Index of the frame that is cached.
+ 
+     std::unique_ptr<Timer<BitmapImage>> m_frameTimer;
+diff --git a/third_party/WebKit/Source/platform/graphics/BitmapImageTest.cpp b/third_party/WebKit/Source/platform/graphics/BitmapImageTest.cpp
+index 81180b47db56757d8fe996bcba709a874900a51c..f64acef907f8a5a0ab4075cdbd6467491f6ef572 100644
+--- a/third_party/WebKit/Source/platform/graphics/BitmapImageTest.cpp
++++ b/third_party/WebKit/Source/platform/graphics/BitmapImageTest.cpp
+@@ -76,7 +76,7 @@ public:
+     // Accessors to BitmapImage's protected methods.
+     void destroyDecodedData() { m_image->destroyDecodedData(); }
+     size_t frameCount() { return m_image->frameCount(); }
+-    PassRefPtr<SkImage> frameAtIndex(size_t index)
++    sk_sp<SkImage> frameAtIndex(size_t index)
+     {
+         return m_image->frameAtIndex(index);
+     }
+diff --git a/third_party/WebKit/Source/platform/graphics/BoxReflection.h b/third_party/WebKit/Source/platform/graphics/BoxReflection.h
+index a7c351d48dd2a912e73ff5382f0afc173290188c..e7492fefd19eff39b7951ddf40fea0aadc512a44 100644
+--- a/third_party/WebKit/Source/platform/graphics/BoxReflection.h
++++ b/third_party/WebKit/Source/platform/graphics/BoxReflection.h
+@@ -7,8 +7,7 @@
+ 
+ #include "platform/PlatformExport.h"
+ #include "third_party/skia/include/core/SkPicture.h"
+-#include "wtf/PassRefPtr.h"
+-#include "wtf/RefPtr.h"
++#include "third_party/skia/include/core/SkRefCnt.h"
+ 
+ class SkImageFilter;
+ class SkMatrix;
+@@ -32,8 +31,8 @@ public:
+         HorizontalReflection,
+     };
+ 
+-    BoxReflection(ReflectionDirection direction, float offset, PassRefPtr<SkPicture> mask = nullptr)
+-        : m_direction(direction), m_offset(offset), m_mask(mask) {}
++    BoxReflection(ReflectionDirection direction, float offset, sk_sp<SkPicture> mask = nullptr)
++        : m_direction(direction), m_offset(offset), m_mask(std::move(mask)) {}
+ 
+     ReflectionDirection direction() const { return m_direction; }
+     float offset() const { return m_offset; }
+@@ -53,7 +52,7 @@ public:
+ private:
+     ReflectionDirection m_direction;
+     float m_offset;
+-    RefPtr<SkPicture> m_mask;
++    sk_sp<SkPicture> m_mask;
+ };
+ 
+ inline bool operator==(const BoxReflection& a, const BoxReflection& b)
+diff --git a/third_party/WebKit/Source/platform/graphics/Canvas2DImageBufferSurface.h b/third_party/WebKit/Source/platform/graphics/Canvas2DImageBufferSurface.h
+index 6ba47bdfa6c6b07a87ebf01179d70f6206dbc915..72ed70f6ecf61e8adbf5083171392b7e6b85cc35 100644
+--- a/third_party/WebKit/Source/platform/graphics/Canvas2DImageBufferSurface.h
++++ b/third_party/WebKit/Source/platform/graphics/Canvas2DImageBufferSurface.h
+@@ -33,6 +33,7 @@
+ 
+ #include "platform/graphics/Canvas2DLayerBridge.h"
+ #include "platform/graphics/ImageBufferSurface.h"
++#include "third_party/skia/include/core/SkRefCnt.h"
+ 
+ namespace blink {
+ 
+@@ -76,7 +77,7 @@ public:
+     void prepareSurfaceForPaintingIfNeeded() override { m_layerBridge->prepareSurfaceForPaintingIfNeeded(); }
+     bool writePixels(const SkImageInfo& origInfo, const void* pixels, size_t rowBytes, int x, int y) override { return m_layerBridge->writePixels(origInfo, pixels, rowBytes, x, y); }
+ 
+-    PassRefPtr<SkImage> newImageSnapshot(AccelerationHint hint, SnapshotReason reason) override { return m_layerBridge->newImageSnapshot(hint, reason); }
++    sk_sp<SkImage> newImageSnapshot(AccelerationHint hint, SnapshotReason reason) override { return m_layerBridge->newImageSnapshot(hint, reason); }
+ 
+ private:
+     void init()
+diff --git a/third_party/WebKit/Source/platform/graphics/Canvas2DLayerBridge.cpp b/third_party/WebKit/Source/platform/graphics/Canvas2DLayerBridge.cpp
+index 4a0048c6f28f48e1abb46b7c278b5c5d87a9153f..9c3efd43eb358154978d766ff9ac5bae348ba151 100644
+--- a/third_party/WebKit/Source/platform/graphics/Canvas2DLayerBridge.cpp
++++ b/third_party/WebKit/Source/platform/graphics/Canvas2DLayerBridge.cpp
+@@ -60,7 +60,7 @@ enum {
+ 
+ namespace blink {
+ 
+-static PassRefPtr<SkSurface> createSkSurface(GrContext* gr, const IntSize& size, int msaaSampleCount, OpacityMode opacityMode, sk_sp<SkColorSpace> colorSpace, bool* surfaceIsAccelerated)
++static sk_sp<SkSurface> createSkSurface(GrContext* gr, const IntSize& size, int msaaSampleCount, OpacityMode opacityMode, sk_sp<SkColorSpace> colorSpace, bool* surfaceIsAccelerated)
+ {
+     if (gr)
+         gr->resetContext();
+@@ -87,7 +87,7 @@ static PassRefPtr<SkSurface> createSkSurface(GrContext* gr, const IntSize& size,
+             surface->getCanvas()->clear(SK_ColorTRANSPARENT);
+         }
+     }
+-    return fromSkSp(surface);
++    return surface;
+ }
+ 
+ Canvas2DLayerBridge::Canvas2DLayerBridge(std::unique_ptr<WebGraphicsContext3DProvider> contextProvider, const IntSize& size, int msaaSampleCount, OpacityMode opacityMode, AccelerationMode accelerationMode, sk_sp<SkColorSpace> colorSpace)
+@@ -292,7 +292,7 @@ void Canvas2DLayerBridge::createMailboxInfo()
+     m_mailboxes.prepend(tmp);
+ }
+ 
+-bool Canvas2DLayerBridge::prepareMailboxFromImage(PassRefPtr<SkImage> image,
++bool Canvas2DLayerBridge::prepareMailboxFromImage(sk_sp<SkImage> image,
+     cc::TextureMailbox* outMailbox)
+ {
+     createMailboxInfo();
+@@ -300,7 +300,7 @@ bool Canvas2DLayerBridge::prepareMailboxFromImage(PassRefPtr<SkImage> image,
+ 
+     GrContext* grContext = m_contextProvider->grContext();
+     if (!grContext) {
+-        mailboxInfo.m_image = image;
++        mailboxInfo.m_image = std::move(image);
+         return true; // for testing: skip gl stuff when using a mock graphics context.
+     }
+ 
+@@ -313,7 +313,7 @@ bool Canvas2DLayerBridge::prepareMailboxFromImage(PassRefPtr<SkImage> image,
+     }
+ #endif // USE_IOSURFACE_FOR_2D_CANVAS
+ 
+-    mailboxInfo.m_image = image;
++    mailboxInfo.m_image = std::move(image);
+ 
+     if (RuntimeEnabledFeatures::forceDisable2dCanvasCopyOnWriteEnabled())
+         m_surface->notifyContentWillChange(SkSurface::kRetain_ContentChangeMode);
+@@ -345,7 +345,7 @@ bool Canvas2DLayerBridge::prepareMailboxFromImage(PassRefPtr<SkImage> image,
+     if (isHidden()) {
+         // With hidden canvases, we release the SkImage immediately because
+         // there is no need for animations to be double buffered.
+-        mailboxInfo.m_image.clear();
++        mailboxInfo.m_image.reset();
+     } else {
+         // FIXME: We'd rather insert a syncpoint than perform a flush here,
+         // but currently the canvas will flicker if we don't flush here.
+@@ -430,8 +430,8 @@ void Canvas2DLayerBridge::hibernate()
+     SkPaint copyPaint;
+     copyPaint.setXfermodeMode(SkXfermode::kSrc_Mode);
+     m_surface->draw(tempHibernationSurface->getCanvas(), 0, 0, &copyPaint); // GPU readback
+-    m_hibernationImage = fromSkSp(tempHibernationSurface->makeImageSnapshot());
+-    m_surface.clear(); // destroy the GPU-backed buffer
++    m_hibernationImage = tempHibernationSurface->makeImageSnapshot();
++    m_surface.reset(); // destroy the GPU-backed buffer
+     m_layer->clearTexture();
+ #if USE_IOSURFACE_FOR_2D_CANVAS
+     clearCHROMIUMImageCache();
+@@ -492,7 +492,7 @@ SkSurface* Canvas2DLayerBridge::getOrCreateSurface(AccelerationHint hint)
+         SkPaint copyPaint;
+         copyPaint.setXfermodeMode(SkXfermode::kSrc_Mode);
+         m_surface->getCanvas()->drawImage(m_hibernationImage.get(), 0, 0, &copyPaint);
+-        m_hibernationImage.clear();
++        m_hibernationImage.reset();
+ 
+         if (m_imageBuffer)
+             m_imageBuffer->updateGPUMemoryUsage();
+@@ -557,12 +557,12 @@ void Canvas2DLayerBridge::beginDestruction()
+         return;
+     if (isHibernating())
+         m_logger->reportHibernationEvent(HibernationEndedWithTeardown);
+-    m_hibernationImage.clear();
++    m_hibernationImage.reset();
+     m_recorder.reset();
+     m_imageBuffer = nullptr;
+     m_destructionInProgress = true;
+     setIsHidden(true);
+-    m_surface.clear();
++    m_surface.reset();
+ 
+     unregisterTaskObserver();
+ 
+@@ -612,7 +612,10 @@ void Canvas2DLayerBridge::setIsHidden(bool hidden)
+         flushRecordingOnly();
+         SkPaint copyPaint;
+         copyPaint.setXfermodeMode(SkXfermode::kSrc_Mode);
+-        RefPtr<SkSurface> oldSurface = m_surface.release();
++
++        sk_sp<SkSurface> oldSurface = std::move(m_surface);
++        m_surface.reset();
++
+         m_softwareRenderingWhileHidden = false;
+         SkSurface* newSurface = getOrCreateSurface(PreferAccelerationAfterVisibilityChange);
+         if (newSurface) {
+@@ -715,10 +718,10 @@ bool Canvas2DLayerBridge::checkSurfaceValid()
+     if (!m_surface)
+         return false;
+     if (m_contextProvider->contextGL()->GetGraphicsResetStatusKHR() != GL_NO_ERROR) {
+-        m_surface.clear();
++        m_surface.reset();
+         for (auto mailboxInfo = m_mailboxes.begin(); mailboxInfo != m_mailboxes.end(); ++mailboxInfo) {
+             if (mailboxInfo->m_image)
+-                mailboxInfo->m_image.clear();
++                mailboxInfo->m_image.reset();
+         }
+         if (m_imageBuffer)
+             m_imageBuffer->notifySurfaceInvalid();
+@@ -743,7 +746,7 @@ bool Canvas2DLayerBridge::restoreSurface()
+     if (sharedGL && sharedGL->GetGraphicsResetStatusKHR() == GL_NO_ERROR) {
+         GrContext* grCtx = m_contextProvider->grContext();
+         bool surfaceIsAccelerated;
+-        RefPtr<SkSurface> surface(createSkSurface(grCtx, m_size, m_msaaSampleCount, m_opacityMode, m_colorSpace, &surfaceIsAccelerated));
++        sk_sp<SkSurface> surface(createSkSurface(grCtx, m_size, m_msaaSampleCount, m_opacityMode, m_colorSpace, &surfaceIsAccelerated));
+ 
+         if (!m_surface)
+             reportSurfaceCreationFailure();
+@@ -752,7 +755,7 @@ bool Canvas2DLayerBridge::restoreSurface()
+         // due to changes to the layer tree, which can only happen at specific times during the document lifecycle.
+         // Therefore, we can only accept the restored surface if it is accelerated.
+         if (surface && surfaceIsAccelerated) {
+-            m_surface = surface.release();
++            m_surface = std::move(surface);
+             // FIXME: draw sad canvas picture into new buffer crbug.com/243842
+         }
+     }
+@@ -812,7 +815,7 @@ bool Canvas2DLayerBridge::PrepareTextureMailbox(
+     if (m_contextProvider->contextGL()->GetGraphicsResetStatusKHR() != GL_NO_ERROR)
+         return false;
+ 
+-    RefPtr<SkImage> image = newImageSnapshot(PreferAcceleration, SnapshotReasonUnknown);
++    sk_sp<SkImage> image = newImageSnapshot(PreferAcceleration, SnapshotReasonUnknown);
+     if (!image || !image->getTexture())
+         return false;
+ 
+@@ -823,7 +826,7 @@ bool Canvas2DLayerBridge::PrepareTextureMailbox(
+     m_lastImageId = image->uniqueID();
+     m_lastFilter = filter;
+ 
+-    if (!prepareMailboxFromImage(image.release(), outMailbox))
++    if (!prepareMailboxFromImage(std::move(image), outMailbox))
+         return false;
+     outMailbox->set_nearest_neighbor(getGLFilter() == GL_NEAREST);
+     gfx::ColorSpace colorSpace = SkColorSpaceToColorSpace(m_colorSpace.get());
+@@ -975,7 +978,7 @@ void Canvas2DLayerBridge::willProcessTask()
+     NOTREACHED();
+ }
+ 
+-PassRefPtr<SkImage> Canvas2DLayerBridge::newImageSnapshot(AccelerationHint hint, SnapshotReason)
++sk_sp<SkImage> Canvas2DLayerBridge::newImageSnapshot(AccelerationHint hint, SnapshotReason)
+ {
+     if (isHibernating())
+         return m_hibernationImage;
+@@ -989,7 +992,7 @@ PassRefPtr<SkImage> Canvas2DLayerBridge::newImageSnapshot(AccelerationHint hint,
+     // even though we are not technically writing to the texture, only to its
+     // parameters.
+     getOrCreateSurface()->notifyContentWillChange(SkSurface::kRetain_ContentChangeMode);
+-    return fromSkSp(m_surface->makeImageSnapshot());
++    return m_surface->makeImageSnapshot();
+ }
+ 
+ void Canvas2DLayerBridge::willOverwriteCanvas()
+diff --git a/third_party/WebKit/Source/platform/graphics/Canvas2DLayerBridge.h b/third_party/WebKit/Source/platform/graphics/Canvas2DLayerBridge.h
+index abca957ac216ac1cbe500dc39994d170c3f68c13..fc94bdce70c3594061c505ef9cf0e4ef2eddb425 100644
+--- a/third_party/WebKit/Source/platform/graphics/Canvas2DLayerBridge.h
++++ b/third_party/WebKit/Source/platform/graphics/Canvas2DLayerBridge.h
+@@ -34,6 +34,7 @@
+ #include "public/platform/WebExternalTextureLayer.h"
+ #include "public/platform/WebThread.h"
+ #include "third_party/khronos/GLES2/gl2.h"
++#include "third_party/skia/include/core/SkRefCnt.h"
+ #include "third_party/skia/include/core/SkSurface.h"
+ #include "wtf/Allocator.h"
+ #include "wtf/Deque.h"
+@@ -125,7 +126,7 @@ public:
+     bool isHibernating() const { return m_hibernationImage.get(); }
+     sk_sp<SkColorSpace> colorSpace() const { return m_colorSpace; }
+ 
+-    PassRefPtr<SkImage> newImageSnapshot(AccelerationHint, SnapshotReason);
++    sk_sp<SkImage> newImageSnapshot(AccelerationHint, SnapshotReason);
+ 
+     // The values of the enum entries must not change because they are used for
+     // usage metrics histograms. New values can be added to the end.
+@@ -176,7 +177,7 @@ private:
+     struct MailboxInfo {
+         DISALLOW_NEW_EXCEPT_PLACEMENT_NEW();
+         gpu::Mailbox m_mailbox;
+-        RefPtr<SkImage> m_image;
++        sk_sp<SkImage> m_image;
+         RefPtr<Canvas2DLayerBridge> m_parentLayerBridge;
+ 
+ #if USE_IOSURFACE_FOR_2D_CANVAS
+@@ -230,15 +231,15 @@ private:
+ 
+     // Returns whether the mailbox was successfully prepared from the SkImage.
+     // The mailbox is an out parameter only populated on success.
+-    bool prepareMailboxFromImage(PassRefPtr<SkImage>, cc::TextureMailbox*);
++    bool prepareMailboxFromImage(sk_sp<SkImage>, cc::TextureMailbox*);
+ 
+     // Resets Skia's texture bindings. This method should be called after
+     // changing texture bindings.
+     void resetSkiaTextureBinding();
+ 
+     std::unique_ptr<SkPictureRecorder> m_recorder;
+-    RefPtr<SkSurface> m_surface;
+-    RefPtr<SkImage> m_hibernationImage;
++    sk_sp<SkSurface> m_surface;
++    sk_sp<SkImage> m_hibernationImage;
+     int m_initialSurfaceSaveCount;
+     std::unique_ptr<WebExternalTextureLayer> m_layer;
+     std::unique_ptr<WebGraphicsContext3DProvider> m_contextProvider;
+diff --git a/third_party/WebKit/Source/platform/graphics/Canvas2DLayerBridgeTest.cpp b/third_party/WebKit/Source/platform/graphics/Canvas2DLayerBridgeTest.cpp
+index bc0740b2ed312271cebecce084d3d7158c4eeca4..f4673ee44d13b839ec5059435af545bd4a6322d7 100644
+--- a/third_party/WebKit/Source/platform/graphics/Canvas2DLayerBridgeTest.cpp
++++ b/third_party/WebKit/Source/platform/graphics/Canvas2DLayerBridgeTest.cpp
+@@ -137,7 +137,7 @@ protected:
+             Canvas2DLayerBridgePtr bridge(adoptRef(new Canvas2DLayerBridge(std::move(contextProvider), IntSize(300, 150), 0, NonOpaque, Canvas2DLayerBridge::EnableAcceleration, nullptr)));
+             EXPECT_TRUE(bridge->checkSurfaceValid());
+             EXPECT_TRUE(bridge->isAccelerated());
+-            RefPtr<SkImage> snapshot = bridge->newImageSnapshot(PreferAcceleration, SnapshotReasonUnitTests);
++            sk_sp<SkImage> snapshot = bridge->newImageSnapshot(PreferAcceleration, SnapshotReasonUnitTests);
+             EXPECT_TRUE(bridge->isAccelerated());
+             EXPECT_TRUE(snapshot->isTextureBacked());
+         }
+@@ -153,7 +153,7 @@ protected:
+             // This will cause SkSurface_Gpu creation to fail without
+             // Canvas2DLayerBridge otherwise detecting that anything was disabled.
+             gr->abandonContext();
+-            RefPtr<SkImage> snapshot = bridge->newImageSnapshot(PreferAcceleration, SnapshotReasonUnitTests);
++            sk_sp<SkImage> snapshot = bridge->newImageSnapshot(PreferAcceleration, SnapshotReasonUnitTests);
+             EXPECT_FALSE(bridge->isAccelerated());
+             EXPECT_FALSE(snapshot->isTextureBacked());
+         }
+@@ -248,7 +248,7 @@ protected:
+             Canvas2DLayerBridgePtr bridge(adoptRef(new Canvas2DLayerBridge(std::move(contextProvider), IntSize(300, 300), 0, NonOpaque, Canvas2DLayerBridge::EnableAcceleration, nullptr)));
+             SkPaint paint;
+             bridge->canvas()->drawRect(SkRect::MakeXYWH(0, 0, 1, 1), paint);
+-            RefPtr<SkImage> image = bridge->newImageSnapshot(PreferAcceleration, SnapshotReasonUnitTests);
++            sk_sp<SkImage> image = bridge->newImageSnapshot(PreferAcceleration, SnapshotReasonUnitTests);
+             EXPECT_TRUE(bridge->checkSurfaceValid());
+             EXPECT_TRUE(bridge->isAccelerated());
+         }
+@@ -259,7 +259,7 @@ protected:
+             Canvas2DLayerBridgePtr bridge(adoptRef(new Canvas2DLayerBridge(std::move(contextProvider), IntSize(300, 300), 0, NonOpaque, Canvas2DLayerBridge::EnableAcceleration, nullptr)));
+             SkPaint paint;
+             bridge->canvas()->drawRect(SkRect::MakeXYWH(0, 0, 1, 1), paint);
+-            RefPtr<SkImage> image = bridge->newImageSnapshot(PreferNoAcceleration, SnapshotReasonUnitTests);
++            sk_sp<SkImage> image = bridge->newImageSnapshot(PreferNoAcceleration, SnapshotReasonUnitTests);
+             EXPECT_TRUE(bridge->checkSurfaceValid());
+             EXPECT_FALSE(bridge->isAccelerated());
+         }
+@@ -796,9 +796,9 @@ TEST_F(Canvas2DLayerBridgeTest, DISABLED_SnapshotWhileHibernating)
+     EXPECT_TRUE(bridge->checkSurfaceValid());
+ 
+     // Take a snapshot and verify that it is not accelerated due to hibernation
+-    RefPtr<SkImage> image = bridge->newImageSnapshot(PreferAcceleration, SnapshotReasonUnitTests);
++    sk_sp<SkImage> image = bridge->newImageSnapshot(PreferAcceleration, SnapshotReasonUnitTests);
+     EXPECT_FALSE(image->isTextureBacked());
+-    image.clear();
++    image.reset();
+ 
+     // Verify that taking a snapshot did not affect the state of bridge
+     EXPECT_FALSE(bridge->isAccelerated());
+diff --git a/third_party/WebKit/Source/platform/graphics/ColorSpace.cpp b/third_party/WebKit/Source/platform/graphics/ColorSpace.cpp
+index 89add3ca6c0b7652d1887ea775d8cef32af207ab..536051f8adeda0b114c2750e4726e54662dbecf8 100644
+--- a/third_party/WebKit/Source/platform/graphics/ColorSpace.cpp
++++ b/third_party/WebKit/Source/platform/graphics/ColorSpace.cpp
+@@ -104,13 +104,13 @@ Color convertColor(const Color& srcColor, ColorSpace dstColorSpace, ColorSpace s
+     return Color(lookupTable[srcColor.red()], lookupTable[srcColor.green()], lookupTable[srcColor.blue()], srcColor.alpha());
+ }
+ 
+-PassRefPtr<SkColorFilter> createColorSpaceFilter(ColorSpace srcColorSpace, ColorSpace dstColorSpace)
++sk_sp<SkColorFilter> createColorSpaceFilter(ColorSpace srcColorSpace, ColorSpace dstColorSpace)
+ {
+     const uint8_t* lookupTable = getConversionLUT(dstColorSpace, srcColorSpace);
+     if (!lookupTable)
+         return nullptr;
+ 
+-    return fromSkSp(SkTableColorFilter::MakeARGB(0, lookupTable, lookupTable, lookupTable));
++    return SkTableColorFilter::MakeARGB(0, lookupTable, lookupTable, lookupTable);
+ }
+ 
+ } // namespace ColorSpaceUtilities
+diff --git a/third_party/WebKit/Source/platform/graphics/ColorSpace.h b/third_party/WebKit/Source/platform/graphics/ColorSpace.h
+index 85b0092c060e6473e62c843de201f11a4ead8727..1818f29cfb606ccf801f356d67747dcd537061c0 100644
+--- a/third_party/WebKit/Source/platform/graphics/ColorSpace.h
++++ b/third_party/WebKit/Source/platform/graphics/ColorSpace.h
+@@ -28,7 +28,7 @@
+ 
+ #include "platform/PlatformExport.h"
+ #include "platform/graphics/Color.h"
+-#include "wtf/PassRefPtr.h"
++#include "third_party/skia/include/core/SkRefCnt.h"
+ 
+ class SkColorFilter;
+ 
+@@ -53,7 +53,7 @@ const uint8_t* getConversionLUT(ColorSpace dstColorSpace, ColorSpace srcColorSpa
+ Color convertColor(const Color& srcColor, ColorSpace dstColorSpace, ColorSpace srcColorSpace = ColorSpaceDeviceRGB);
+ 
+ // Create a color filter that will convert from |srcColorSpace| into |dstColorSpace|.
+-PassRefPtr<SkColorFilter> createColorSpaceFilter(ColorSpace srcColorSpace, ColorSpace dstColorSpace);
++sk_sp<SkColorFilter> createColorSpaceFilter(ColorSpace srcColorSpace, ColorSpace dstColorSpace);
+ 
+ } // namespace ColorSpaceUtilities
+ 
+diff --git a/third_party/WebKit/Source/platform/graphics/DeferredImageDecoder.cpp b/third_party/WebKit/Source/platform/graphics/DeferredImageDecoder.cpp
+index 7c32145a13293b0ed26f95f07cd21cd144b3c729..143ff3b833956c38b8207d3dd1edd17361b44ea7 100644
+--- a/third_party/WebKit/Source/platform/graphics/DeferredImageDecoder.cpp
++++ b/third_party/WebKit/Source/platform/graphics/DeferredImageDecoder.cpp
+@@ -99,7 +99,7 @@ String DeferredImageDecoder::filenameExtension() const
+     return m_actualDecoder ? m_actualDecoder->filenameExtension() : m_filenameExtension;
+ }
+ 
+-PassRefPtr<SkImage> DeferredImageDecoder::createFrameAtIndex(size_t index)
++sk_sp<SkImage> DeferredImageDecoder::createFrameAtIndex(size_t index)
+ {
+     if (m_frameGenerator && m_frameGenerator->decodeFailed())
+         return nullptr;
+@@ -125,14 +125,14 @@ PassRefPtr<SkImage> DeferredImageDecoder::createFrameAtIndex(size_t index)
+     if (!frame || frame->getStatus() == ImageFrame::FrameEmpty)
+         return nullptr;
+ 
+-    return fromSkSp(SkImage::MakeFromBitmap(frame->bitmap()));
++    return (frame->getStatus() == ImageFrame::FrameComplete) ? frame->finalizePixelsAndGetImage() : SkImage::MakeFromBitmap(frame->bitmap());
+ }
+ 
+ PassRefPtr<SharedBuffer> DeferredImageDecoder::data()
+ {
+     if (!m_rwBuffer)
+         return nullptr;
+-    RefPtr<SkROBuffer> roBuffer = adoptRef(m_rwBuffer->newRBufferSnapshot());
++    sk_sp<SkROBuffer> roBuffer(m_rwBuffer->newRBufferSnapshot());
+     RefPtr<SharedBuffer> sharedBuffer = SharedBuffer::create();
+     SkROBuffer::Iter it(roBuffer.get());
+     do {
+@@ -318,16 +318,16 @@ inline SkImageInfo imageInfoFrom(const SkISize& decodedSize, bool knownToBeOpaqu
+     return SkImageInfo::MakeN32(decodedSize.width(), decodedSize.height(), knownToBeOpaque ? kOpaque_SkAlphaType : kPremul_SkAlphaType);
+ }
+ 
+-PassRefPtr<SkImage> DeferredImageDecoder::createFrameImageAtIndex(size_t index, bool knownToBeOpaque)
++sk_sp<SkImage> DeferredImageDecoder::createFrameImageAtIndex(size_t index, bool knownToBeOpaque)
+ {
+     const SkISize& decodedSize = m_frameGenerator->getFullSize();
+     ASSERT(decodedSize.width() > 0);
+     ASSERT(decodedSize.height() > 0);
+ 
+-    RefPtr<SkROBuffer> roBuffer = adoptRef(m_rwBuffer->newRBufferSnapshot());
+-    RefPtr<SegmentReader> segmentReader = SegmentReader::createFromSkROBuffer(roBuffer.release());
++    sk_sp<SkROBuffer> roBuffer(m_rwBuffer->newRBufferSnapshot());
++    RefPtr<SegmentReader> segmentReader = SegmentReader::createFromSkROBuffer(std::move(roBuffer));
+     DecodingImageGenerator* generator = new DecodingImageGenerator(m_frameGenerator, imageInfoFrom(decodedSize, knownToBeOpaque), segmentReader.release(), m_allDataReceived, index, m_frameData[index].m_uniqueID);
+-    RefPtr<SkImage> image = fromSkSp(SkImage::MakeFromGenerator(generator)); // SkImage takes ownership of the generator.
++    sk_sp<SkImage> image = SkImage::MakeFromGenerator(generator); // SkImage takes ownership of the generator.
+     if (!image)
+         return nullptr;
+ 
+@@ -341,7 +341,7 @@ PassRefPtr<SkImage> DeferredImageDecoder::createFrameImageAtIndex(size_t index,
+ 
+     generator->setCanYUVDecode(m_canYUVDecode);
+ 
+-    return image.release();
++    return image;
+ }
+ 
+ bool DeferredImageDecoder::hotSpot(IntPoint& hotSpot) const
+diff --git a/third_party/WebKit/Source/platform/graphics/DeferredImageDecoder.h b/third_party/WebKit/Source/platform/graphics/DeferredImageDecoder.h
+index b2a8aea67fdf6a47341216ff4fea11297ee2bc45..993f139e0e2e91c535d41f1b541e25f8f28b1cf5 100644
+--- a/third_party/WebKit/Source/platform/graphics/DeferredImageDecoder.h
++++ b/third_party/WebKit/Source/platform/graphics/DeferredImageDecoder.h
+@@ -30,6 +30,7 @@
+ #include "platform/geometry/IntSize.h"
+ #include "platform/image-decoders/ImageDecoder.h"
+ #include "third_party/skia/include/core/SkRWBuffer.h"
++#include "third_party/skia/include/core/SkRefCnt.h"
+ #include "wtf/Allocator.h"
+ #include "wtf/Forward.h"
+ #include "wtf/Vector.h"
+@@ -56,7 +57,7 @@ public:
+ 
+     String filenameExtension() const;
+ 
+-    PassRefPtr<SkImage> createFrameAtIndex(size_t);
++    sk_sp<SkImage> createFrameAtIndex(size_t);
+ 
+     PassRefPtr<SharedBuffer> data();
+     void setData(PassRefPtr<SharedBuffer> data, bool allDataReceived);
+@@ -84,7 +85,7 @@ private:
+     void activateLazyDecoding();
+     void prepareLazyDecodedFrames();
+ 
+-    PassRefPtr<SkImage> createFrameImageAtIndex(size_t index, bool knownToBeOpaque);
++    sk_sp<SkImage> createFrameImageAtIndex(size_t index, bool knownToBeOpaque);
+ 
+     void setDataInternal(PassRefPtr<SharedBuffer> data, bool allDataReceived, bool pushDataToDecoder);
+ 
+diff --git a/third_party/WebKit/Source/platform/graphics/DeferredImageDecoderTest.cpp b/third_party/WebKit/Source/platform/graphics/DeferredImageDecoderTest.cpp
+index 6aaf06c546152cde532eb69768cf9814c2087459..6cfec04abefaac70b4228176fefac9b155a89ed3 100644
+--- a/third_party/WebKit/Source/platform/graphics/DeferredImageDecoderTest.cpp
++++ b/third_party/WebKit/Source/platform/graphics/DeferredImageDecoderTest.cpp
+@@ -176,7 +176,7 @@ protected:
+ TEST_F(DeferredImageDecoderTest, drawIntoSkPicture)
+ {
+     m_lazyDecoder->setData(m_data, true);
+-    RefPtr<SkImage> image = m_lazyDecoder->createFrameAtIndex(0);
++    sk_sp<SkImage> image = m_lazyDecoder->createFrameAtIndex(0);
+     ASSERT_TRUE(image);
+     EXPECT_EQ(1, image->width());
+     EXPECT_EQ(1, image->height());
+@@ -203,7 +203,7 @@ TEST_F(DeferredImageDecoderTest, drawIntoSkPictureProgressive)
+ 
+     // Received only half the file.
+     m_lazyDecoder->setData(partialData, false);
+-    RefPtr<SkImage> image = m_lazyDecoder->createFrameAtIndex(0);
++    sk_sp<SkImage> image = m_lazyDecoder->createFrameAtIndex(0);
+     ASSERT_TRUE(image);
+     SkPictureRecorder recorder;
+     SkCanvas* tempCanvas = recorder.beginRecording(100, 100, 0, 0);
+@@ -233,7 +233,7 @@ static void rasterizeMain(SkCanvas* canvas, SkPicture* picture)
+ TEST_F(DeferredImageDecoderTest, decodeOnOtherThread)
+ {
+     m_lazyDecoder->setData(m_data, true);
+-    RefPtr<SkImage> image = m_lazyDecoder->createFrameAtIndex(0);
++    sk_sp<SkImage> image = m_lazyDecoder->createFrameAtIndex(0);
+     ASSERT_TRUE(image);
+     EXPECT_EQ(1, image->width());
+     EXPECT_EQ(1, image->height());
+@@ -262,7 +262,7 @@ TEST_F(DeferredImageDecoderTest, singleFrameImageLoading)
+     m_status = ImageFrame::FramePartial;
+     m_lazyDecoder->setData(m_data, false);
+     EXPECT_FALSE(m_lazyDecoder->frameIsCompleteAtIndex(0));
+-    RefPtr<SkImage> image = m_lazyDecoder->createFrameAtIndex(0);
++    sk_sp<SkImage> image = m_lazyDecoder->createFrameAtIndex(0);
+     ASSERT_TRUE(image);
+     unsigned firstId = image->uniqueID();
+     EXPECT_FALSE(m_lazyDecoder->frameIsCompleteAtIndex(0));
+@@ -289,7 +289,7 @@ TEST_F(DeferredImageDecoderTest, multiFrameImageLoading)
+     m_status = ImageFrame::FramePartial;
+     m_lazyDecoder->setData(m_data, false);
+ 
+-    RefPtr<SkImage> image = m_lazyDecoder->createFrameAtIndex(0);
++    sk_sp<SkImage> image = m_lazyDecoder->createFrameAtIndex(0);
+     ASSERT_TRUE(image);
+     unsigned firstId = image->uniqueID();
+     EXPECT_FALSE(m_lazyDecoder->frameIsCompleteAtIndex(0));
+@@ -328,7 +328,7 @@ TEST_F(DeferredImageDecoderTest, decodedSize)
+ {
+     m_decodedSize = IntSize(22, 33);
+     m_lazyDecoder->setData(m_data, true);
+-    RefPtr<SkImage> image = m_lazyDecoder->createFrameAtIndex(0);
++    sk_sp<SkImage> image = m_lazyDecoder->createFrameAtIndex(0);
+     ASSERT_TRUE(image);
+     EXPECT_EQ(m_decodedSize.width(), image->width());
+     EXPECT_EQ(m_decodedSize.height(), image->height());
+@@ -372,7 +372,7 @@ TEST_F(DeferredImageDecoderTest, frameOpacity)
+     SkPixmap pixmap(pixInfo, storage.get(), rowBytes);
+ 
+     // Before decoding, the frame is not known to be opaque.
+-    RefPtr<SkImage> frame = decoder->createFrameAtIndex(0);
++    sk_sp<SkImage> frame = decoder->createFrameAtIndex(0);
+     ASSERT_TRUE(frame);
+     EXPECT_FALSE(frame->isOpaque());
+ 
+diff --git a/third_party/WebKit/Source/platform/graphics/DeferredImageDecoderTestWoPlatform.cpp b/third_party/WebKit/Source/platform/graphics/DeferredImageDecoderTestWoPlatform.cpp
+index b72c123a108851a1cc6dfc8c79ed27fc36805cc1..57dd731b04f68aa53f49ef2ee0b5d5a6a6374ac1 100644
+--- a/third_party/WebKit/Source/platform/graphics/DeferredImageDecoderTestWoPlatform.cpp
++++ b/third_party/WebKit/Source/platform/graphics/DeferredImageDecoderTestWoPlatform.cpp
+@@ -39,11 +39,11 @@ static void mixImages(const char* fileName, size_t bytesForFirstFrame, size_t la
+     std::unique_ptr<DeferredImageDecoder> decoder = DeferredImageDecoder::create(partialFile, false,
+         ImageDecoder::AlphaPremultiplied, ImageDecoder::GammaAndColorProfileIgnored);
+     ASSERT_NE(decoder, nullptr);
+-    RefPtr<SkImage> partialImage = decoder->createFrameAtIndex(0);
++    sk_sp<SkImage> partialImage = decoder->createFrameAtIndex(0);
+ 
+     RefPtr<SharedBuffer> almostCompleteFile = SharedBuffer::create(file->data(), file->size() - 1);
+     decoder->setData(almostCompleteFile, false);
+-    RefPtr<SkImage> imageWithMoreData = decoder->createFrameAtIndex(laterFrame);
++    sk_sp<SkImage> imageWithMoreData = decoder->createFrameAtIndex(laterFrame);
+ 
+     imageWithMoreData->preroll();
+     partialImage->preroll();
+diff --git a/third_party/WebKit/Source/platform/graphics/DrawLooperBuilder.cpp b/third_party/WebKit/Source/platform/graphics/DrawLooperBuilder.cpp
+index 018d193265b35d7b0e863e15efed436f0a048856..30c2551d6d93603f35cd055dbfd0d73e0c128557 100644
+--- a/third_party/WebKit/Source/platform/graphics/DrawLooperBuilder.cpp
++++ b/third_party/WebKit/Source/platform/graphics/DrawLooperBuilder.cpp
+@@ -54,9 +54,9 @@ std::unique_ptr<DrawLooperBuilder> DrawLooperBuilder::create()
+     return wrapUnique(new DrawLooperBuilder);
+ }
+ 
+-PassRefPtr<SkDrawLooper> DrawLooperBuilder::detachDrawLooper()
++sk_sp<SkDrawLooper> DrawLooperBuilder::detachDrawLooper()
+ {
+-    return fromSkSp(m_skDrawLooperBuilder.detach());
++    return m_skDrawLooperBuilder.detach();
+ }
+ 
+ void DrawLooperBuilder::addUnmodifiedContent()
+diff --git a/third_party/WebKit/Source/platform/graphics/DrawLooperBuilder.h b/third_party/WebKit/Source/platform/graphics/DrawLooperBuilder.h
+index eeb03dfd87f493f6a68839f4e211fc4cb42a9410..6a92e8d34c44b9daa6c812d049f042daf2ed1396 100644
+--- a/third_party/WebKit/Source/platform/graphics/DrawLooperBuilder.h
++++ b/third_party/WebKit/Source/platform/graphics/DrawLooperBuilder.h
+@@ -32,10 +32,10 @@
+ #define DrawLooperBuilder_h
+ 
+ #include "platform/PlatformExport.h"
++#include "third_party/skia/include/core/SkRefCnt.h"
+ #include "third_party/skia/include/effects/SkLayerDrawLooper.h"
+ #include "wtf/Allocator.h"
+ #include "wtf/Noncopyable.h"
+-#include "wtf/PassRefPtr.h"
+ #include <memory>
+ 
+ class SkDrawLooper;
+@@ -68,7 +68,7 @@ public:
+ 
+     // Creates the SkDrawLooper and passes ownership to the caller. The builder
+     // should not be used any more after calling this method.
+-    PassRefPtr<SkDrawLooper> detachDrawLooper();
++    sk_sp<SkDrawLooper> detachDrawLooper();
+ 
+     void addUnmodifiedContent();
+     void addShadow(const FloatSize& offset, float blur, const Color&,
+diff --git a/third_party/WebKit/Source/platform/graphics/GeneratedImage.cpp b/third_party/WebKit/Source/platform/graphics/GeneratedImage.cpp
+index 874dc95f56eb2e3091df6bf0d2b97bbd4c8efc23..49f8de17a0d04f724b179dfd751b56a7e3f78786 100644
+--- a/third_party/WebKit/Source/platform/graphics/GeneratedImage.cpp
++++ b/third_party/WebKit/Source/platform/graphics/GeneratedImage.cpp
+@@ -48,13 +48,13 @@ void GeneratedImage::drawPattern(GraphicsContext& destContext, const FloatRect&
+     SkPictureBuilder builder(tileRect, nullptr, &destContext);
+     builder.context().beginRecording(tileRect);
+     drawTile(builder.context(), srcRect);
+-    RefPtr<SkPicture> tilePicture = builder.endRecording();
++    sk_sp<SkPicture> tilePicture = builder.endRecording();
+ 
+     SkMatrix patternMatrix = SkMatrix::MakeTrans(phase.x(), phase.y());
+     patternMatrix.preScale(scale.width(), scale.height());
+     patternMatrix.preTranslate(tileRect.x(), tileRect.y());
+ 
+-    RefPtr<Pattern> picturePattern = Pattern::createPicturePattern(tilePicture.release());
++    RefPtr<Pattern> picturePattern = Pattern::createPicturePattern(std::move(tilePicture));
+ 
+     SkPaint fillPaint = destContext.fillPaint();
+     picturePattern->applyToPaint(fillPaint, patternMatrix);
+@@ -64,7 +64,7 @@ void GeneratedImage::drawPattern(GraphicsContext& destContext, const FloatRect&
+     destContext.drawRect(destRect, fillPaint);
+ }
+ 
+-PassRefPtr<SkImage> GeneratedImage::imageForCurrentFrame()
++sk_sp<SkImage> GeneratedImage::imageForCurrentFrame()
+ {
+     return nullptr;
+ }
+diff --git a/third_party/WebKit/Source/platform/graphics/GeneratedImage.h b/third_party/WebKit/Source/platform/graphics/GeneratedImage.h
+index fadc7551fe81729c111f2b9ddcca42ba45b21324..330bd7b258303e936b7f521c7967461f738c44ce 100644
+--- a/third_party/WebKit/Source/platform/graphics/GeneratedImage.h
++++ b/third_party/WebKit/Source/platform/graphics/GeneratedImage.h
+@@ -28,7 +28,7 @@
+ 
+ #include "platform/geometry/IntSize.h"
+ #include "platform/graphics/Image.h"
+-#include "wtf/RefPtr.h"
++#include "third_party/skia/include/core/SkRefCnt.h"
+ 
+ namespace blink {
+ 
+@@ -44,7 +44,7 @@ public:
+     // Assume that generated content has no decoded data we need to worry about
+     void destroyDecodedData() override { }
+ 
+-    PassRefPtr<SkImage> imageForCurrentFrame() override;
++    sk_sp<SkImage> imageForCurrentFrame() override;
+ 
+ protected:
+     void drawPattern(GraphicsContext&, const FloatRect&,
+diff --git a/third_party/WebKit/Source/platform/graphics/GraphicsContext.cpp b/third_party/WebKit/Source/platform/graphics/GraphicsContext.cpp
+index 43ef58f8fabca3a7951566d19250c35075be5ee8..c68327bd448e426ead295cb2987b8d1e351f4d39 100644
+--- a/third_party/WebKit/Source/platform/graphics/GraphicsContext.cpp
++++ b/third_party/WebKit/Source/platform/graphics/GraphicsContext.cpp
+@@ -77,7 +77,7 @@ GraphicsContext::GraphicsContext(PaintController& paintController, DisabledMode
+     m_paintState = m_paintStateStack.last().get();
+ 
+     if (contextDisabled()) {
+-        DEFINE_STATIC_REF(SkCanvas, nullCanvas, (adoptRef(SkCreateNullCanvas())));
++        DEFINE_STATIC_LOCAL(SkCanvas*, nullCanvas, (SkCreateNullCanvas()));
+         m_canvas = nullCanvas;
+     }
+ }
+@@ -236,7 +236,7 @@ void GraphicsContext::beginLayer(float opacity, SkXfermode::Mode xfermode, const
+     SkPaint layerPaint;
+     layerPaint.setAlpha(static_cast<unsigned char>(opacity * 255));
+     layerPaint.setXfermodeMode(xfermode);
+-    layerPaint.setColorFilter(toSkSp(WebCoreColorFilterToSkiaColorFilter(colorFilter)));
++    layerPaint.setColorFilter(WebCoreColorFilterToSkiaColorFilter(colorFilter));
+     layerPaint.setImageFilter(std::move(imageFilter));
+ 
+     if (bounds) {
+@@ -273,28 +273,28 @@ void GraphicsContext::beginRecording(const FloatRect& bounds)
+ 
+ namespace {
+ 
+-PassRefPtr<SkPicture> createEmptyPicture()
++sk_sp<SkPicture> createEmptyPicture()
+ {
+     SkPictureRecorder recorder;
+     recorder.beginRecording(SkRect::MakeEmpty(), nullptr);
+-    return fromSkSp(recorder.finishRecordingAsPicture());
++    return recorder.finishRecordingAsPicture();
+ }
+ 
+ } // anonymous namespace
+ 
+-PassRefPtr<SkPicture> GraphicsContext::endRecording()
++sk_sp<SkPicture> GraphicsContext::endRecording()
+ {
+     if (contextDisabled()) {
+         // Clients expect endRecording() to always return a non-null picture.
+         // Cache an empty SKP to minimize overhead when disabled.
+-        DEFINE_STATIC_REF(SkPicture, emptyPicture, createEmptyPicture());
++        DEFINE_STATIC_LOCAL(sk_sp<SkPicture>, emptyPicture, (createEmptyPicture()));
+         return emptyPicture;
+     }
+ 
+-    RefPtr<SkPicture> picture = fromSkSp(m_pictureRecorder.finishRecordingAsPicture());
++    sk_sp<SkPicture> picture = m_pictureRecorder.finishRecordingAsPicture();
+     m_canvas = nullptr;
+     ASSERT(picture);
+-    return picture.release();
++    return picture;
+ }
+ 
+ void GraphicsContext::drawPicture(const SkPicture* picture)
+@@ -306,7 +306,7 @@ void GraphicsContext::drawPicture(const SkPicture* picture)
+     m_canvas->drawPicture(picture);
+ }
+ 
+-void GraphicsContext::compositePicture(PassRefPtr<SkPicture> picture, const FloatRect& dest, const FloatRect& src, SkXfermode::Mode op)
++void GraphicsContext::compositePicture(sk_sp<SkPicture> picture, const FloatRect& dest, const FloatRect& src, SkXfermode::Mode op)
+ {
+     if (contextDisabled() || !picture)
+         return;
+@@ -320,7 +320,7 @@ void GraphicsContext::compositePicture(PassRefPtr<SkPicture> picture, const Floa
+     SkMatrix pictureTransform;
+     pictureTransform.setRectToRect(sourceBounds, skBounds, SkMatrix::kFill_ScaleToFit);
+     m_canvas->concat(pictureTransform);
+-    picturePaint.setImageFilter(SkPictureImageFilter::MakeForLocalSpace(toSkSp(picture), sourceBounds, static_cast<SkFilterQuality>(imageInterpolationQuality())));
++    picturePaint.setImageFilter(SkPictureImageFilter::MakeForLocalSpace(std::move(picture), sourceBounds, static_cast<SkFilterQuality>(imageInterpolationQuality())));
+     m_canvas->saveLayer(&sourceBounds, &picturePaint);
+     m_canvas->restore();
+     m_canvas->restore();
+@@ -1226,11 +1226,11 @@ void GraphicsContext::adjustLineToPixelBoundaries(FloatPoint& p1, FloatPoint& p2
+     }
+ }
+ 
+-PassRefPtr<SkColorFilter> GraphicsContext::WebCoreColorFilterToSkiaColorFilter(ColorFilter colorFilter)
++sk_sp<SkColorFilter> GraphicsContext::WebCoreColorFilterToSkiaColorFilter(ColorFilter colorFilter)
+ {
+     switch (colorFilter) {
+     case ColorFilterLuminanceToAlpha:
+-        return fromSkSp(SkLumaColorFilter::Make());
++        return SkLumaColorFilter::Make();
+     case ColorFilterLinearRGBToSRGB:
+         return ColorSpaceUtilities::createColorSpaceFilter(ColorSpaceLinearRGB, ColorSpaceDeviceRGB);
+     case ColorFilterSRGBToLinearRGB:
+diff --git a/third_party/WebKit/Source/platform/graphics/GraphicsContext.h b/third_party/WebKit/Source/platform/graphics/GraphicsContext.h
+index 71fde7edaa75c97d6418e8c14a66dfe454fdba5a..6cdbe0b341bdc52899e65f573c615d55ba27fd30 100644
+--- a/third_party/WebKit/Source/platform/graphics/GraphicsContext.h
++++ b/third_party/WebKit/Source/platform/graphics/GraphicsContext.h
+@@ -37,6 +37,7 @@
+ #include "platform/graphics/skia/SkiaUtils.h"
+ #include "third_party/skia/include/core/SkMetaData.h"
+ #include "third_party/skia/include/core/SkPictureRecorder.h"
++#include "third_party/skia/include/core/SkRefCnt.h"
+ #include "third_party/skia/include/core/SkRegion.h"
+ #include "wtf/Allocator.h"
+ #include "wtf/Forward.h"
+@@ -151,7 +152,7 @@ public:
+     void strokeRect(const FloatRect&, float lineWidth);
+ 
+     void drawPicture(const SkPicture*);
+-    void compositePicture(PassRefPtr<SkPicture>, const FloatRect& dest, const FloatRect& src, SkXfermode::Mode);
++    void compositePicture(sk_sp<SkPicture>, const FloatRect& dest, const FloatRect& src, SkXfermode::Mode);
+ 
+     void drawImage(Image*, const FloatRect& destRect, const FloatRect* srcRect = nullptr,
+         SkXfermode::Mode = SkXfermode::kSrcOver_Mode, RespectImageOrientationEnum = DoNotRespectImageOrientation);
+@@ -206,7 +207,7 @@ public:
+     // Returns a picture with any recorded draw commands since the prerequisite call to
+     // beginRecording().  The picture is guaranteed to be non-null (but not necessarily non-empty),
+     // even when the context is disabled.
+-    PassRefPtr<SkPicture> endRecording();
++    sk_sp<SkPicture> endRecording();
+ 
+     void setShadow(const FloatSize& offset, float blur, const Color&,
+         DrawLooperBuilder::ShadowTransformMode = DrawLooperBuilder::ShadowRespectsTransforms,
+@@ -275,7 +276,7 @@ public:
+     void setInDrawingRecorder(bool);
+ #endif
+ 
+-    static PassRefPtr<SkColorFilter> WebCoreColorFilterToSkiaColorFilter(ColorFilter);
++    static sk_sp<SkColorFilter> WebCoreColorFilterToSkiaColorFilter(ColorFilter);
+ 
+ private:
+     const GraphicsContextState* immutableState() const { return m_paintState; }
+diff --git a/third_party/WebKit/Source/platform/graphics/GraphicsContextState.cpp b/third_party/WebKit/Source/platform/graphics/GraphicsContextState.cpp
+index 33bcbd60729ad12adc4739e187fe36dd0b4c70ef..20b13de704be87c332ee5972e5c5ea04021feaa6 100644
+--- a/third_party/WebKit/Source/platform/graphics/GraphicsContextState.cpp
++++ b/third_party/WebKit/Source/platform/graphics/GraphicsContextState.cpp
+@@ -97,12 +97,12 @@ void GraphicsContextState::setFillColor(const Color& color)
+ }
+ 
+ // Shadow. (This will need tweaking if we use draw loopers for other things.)
+-void GraphicsContextState::setDrawLooper(PassRefPtr<SkDrawLooper> drawLooper)
++void GraphicsContextState::setDrawLooper(sk_sp<SkDrawLooper> drawLooper)
+ {
+     // Grab a new ref for stroke.
+     m_strokePaint.setLooper(sk_ref_sp(drawLooper.get()));
+     // Pass the existing ref to fill (to minimize refcount churn).
+-    m_fillPaint.setLooper(toSkSp(drawLooper));
++    m_fillPaint.setLooper(std::move(drawLooper));
+ }
+ 
+ void GraphicsContextState::setLineDash(const DashArray& dashes, float dashOffset)
+@@ -110,12 +110,12 @@ void GraphicsContextState::setLineDash(const DashArray& dashes, float dashOffset
+     m_strokeData.setLineDash(dashes, dashOffset);
+ }
+ 
+-void GraphicsContextState::setColorFilter(PassRefPtr<SkColorFilter> colorFilter)
++void GraphicsContextState::setColorFilter(sk_sp<SkColorFilter> colorFilter)
+ {
+     // Grab a new ref for stroke.
+     m_strokePaint.setColorFilter(sk_ref_sp(colorFilter.get()));
+     // Pass the existing ref to fill (to minimize refcount churn).
+-    m_fillPaint.setColorFilter(toSkSp(colorFilter));
++    m_fillPaint.setColorFilter(std::move(colorFilter));
+ }
+ 
+ void GraphicsContextState::setInterpolationQuality(InterpolationQuality quality)
+diff --git a/third_party/WebKit/Source/platform/graphics/GraphicsContextState.h b/third_party/WebKit/Source/platform/graphics/GraphicsContextState.h
+index b8605c5bbc91893642f805079c1c76f3294657f7..88bf6a7018630218d3cbc3a9dbdfd642e44baf7b 100644
+--- a/third_party/WebKit/Source/platform/graphics/GraphicsContextState.h
++++ b/third_party/WebKit/Source/platform/graphics/GraphicsContextState.h
+@@ -34,10 +34,10 @@
+ #include "platform/graphics/StrokeData.h"
+ #include "third_party/skia/include/core/SkColorFilter.h"
+ #include "third_party/skia/include/core/SkPaint.h"
++#include "third_party/skia/include/core/SkRefCnt.h"
+ #include "wtf/Allocator.h"
+ #include "wtf/Noncopyable.h"
+ #include "wtf/PtrUtil.h"
+-#include "wtf/RefPtr.h"
+ #include <memory>
+ 
+ namespace blink {
+@@ -90,7 +90,7 @@ public:
+         DCHECK_EQ(m_fillPaint.getLooper(), m_strokePaint.getLooper());
+         return m_fillPaint.getLooper();
+     }
+-    void setDrawLooper(PassRefPtr<SkDrawLooper>);
++    void setDrawLooper(sk_sp<SkDrawLooper>);
+ 
+     // Text. (See TextModeFill & friends.)
+     TextDrawingModeFlags textDrawingMode() const { return m_textDrawingMode; }
+@@ -101,7 +101,7 @@ public:
+         DCHECK_EQ(m_fillPaint.getColorFilter(), m_strokePaint.getColorFilter());
+         return m_fillPaint.getColorFilter();
+     }
+-    void setColorFilter(PassRefPtr<SkColorFilter>);
++    void setColorFilter(sk_sp<SkColorFilter>);
+ 
+     // Image interpolation control.
+     InterpolationQuality getInterpolationQuality() const { return m_interpolationQuality; }
+diff --git a/third_party/WebKit/Source/platform/graphics/GraphicsContextTest.cpp b/third_party/WebKit/Source/platform/graphics/GraphicsContextTest.cpp
+index 5b5886e53fbab9f10c28584a257ae23f4d209edf..54d8e18fcc1d1b64e26bca39b45ed3637a292e57 100644
+--- a/third_party/WebKit/Source/platform/graphics/GraphicsContextTest.cpp
++++ b/third_party/WebKit/Source/platform/graphics/GraphicsContextTest.cpp
+@@ -78,7 +78,7 @@ TEST(GraphicsContextTest, pictureRecording)
+ 
+     context.beginRecording(bounds);
+     context.fillRect(FloatRect(0, 0, 50, 50), opaque, SkXfermode::kSrcOver_Mode);
+-    RefPtr<const SkPicture> picture = context.endRecording();
++    sk_sp<const SkPicture> picture = context.endRecording();
+     canvas.drawPicture(picture.get());
+     EXPECT_OPAQUE_PIXELS_ONLY_IN_RECT(bitmap, IntRect(0, 0, 50, 50))
+ 
+@@ -121,7 +121,7 @@ TEST(GraphicsContextTest, UnboundedDrawsAreClipped)
+ 
+     // Make the device opaque in 10,10 40x40.
+     context.fillRect(FloatRect(10, 10, 40, 40), opaque, SkXfermode::kSrcOver_Mode);
+-    RefPtr<const SkPicture> picture = context.endRecording();
++    sk_sp<const SkPicture> picture = context.endRecording();
+     canvas.drawPicture(picture.get());
+     EXPECT_OPAQUE_PIXELS_ONLY_IN_RECT(bitmap, IntRect(10, 10, 40, 40));
+ 
+diff --git a/third_party/WebKit/Source/platform/graphics/GraphicsLayer.cpp b/third_party/WebKit/Source/platform/graphics/GraphicsLayer.cpp
+index 397eac0d20b151c7d539ff737b18325214f55eab..eace77f90571c4e1bc84e282706f497948aaa34c 100644
+--- a/third_party/WebKit/Source/platform/graphics/GraphicsLayer.cpp
++++ b/third_party/WebKit/Source/platform/graphics/GraphicsLayer.cpp
+@@ -94,7 +94,7 @@ struct PaintInvalidationTracking {
+     DISALLOW_NEW_EXCEPT_PLACEMENT_NEW();
+     Vector<PaintInvalidationInfo> trackedPaintInvalidations;
+ #if DCHECK_IS_ON()
+-    RefPtr<SkPicture> lastPaintedPicture;
++    sk_sp<SkPicture> lastPaintedPicture;
+     Region paintInvalidationRegionSinceLastPaint;
+     Vector<UnderPaintInvalidation> underPaintInvalidations;
+ #endif
+@@ -339,9 +339,10 @@ void GraphicsLayer::paint(const IntRect* interestRect, GraphicsContext::Disabled
+ #if DCHECK_IS_ON()
+         if (RuntimeEnabledFeatures::slimmingPaintUnderInvalidationCheckingEnabled()) {
+             RefPtr<SkPicture> newPicture = capturePicture();
++            sk_sp<SkPicture> newPicture = capturePicture();
+             checkPaintUnderInvalidations(*newPicture);
+             PaintInvalidationTracking& tracking = paintInvalidationTrackingMap().add(this, PaintInvalidationTracking()).storedValue->value;
+-            tracking.lastPaintedPicture = newPicture;
++            tracking.lastPaintedPicture = std::move(newPicture);
+             tracking.paintInvalidationRegionSinceLastPaint = Region();
+         }
+ #endif
+@@ -1120,12 +1121,12 @@ void GraphicsLayer::setContentsRect(const IntRect& rect)
+ 
+ void GraphicsLayer::setContentsToImage(Image* image, RespectImageOrientationEnum respectImageOrientation)
+ {
+-    RefPtr<SkImage> skImage = image ? image->imageForCurrentFrame() : nullptr;
++    sk_sp<SkImage> skImage = image ? image->imageForCurrentFrame() : nullptr;
+ 
+     if (image && skImage && image->isBitmapImage()) {
+         if (respectImageOrientation == RespectImageOrientation) {
+             ImageOrientation imageOrientation = toBitmapImage(image)->currentFrameOrientation();
+-            skImage = DragImage::resizeAndOrientImage(skImage.release(), imageOrientation);
++            skImage = DragImage::resizeAndOrientImage(std::move(skImage), imageOrientation);
+         }
+     }
+ 
+@@ -1255,7 +1256,7 @@ void GraphicsLayer::setCompositorMutableProperties(uint32_t properties)
+ 
+ #if DCHECK_IS_ON()
+ 
+-PassRefPtr<SkPicture> GraphicsLayer::capturePicture()
++sk_sp<SkPicture> GraphicsLayer::capturePicture()
+ {
+     if (!drawsContent())
+         return nullptr;
+@@ -1338,7 +1339,7 @@ void GraphicsLayer::checkPaintUnderInvalidations(const SkPicture& newPicture)
+     SkPictureRecorder recorder;
+     recorder.beginRecording(width, height);
+     recorder.getRecordingCanvas()->drawBitmap(newBitmap, 0, 0);
+-    RefPtr<SkPicture> picture = fromSkSp(recorder.finishRecordingAsPicture());
++    sk_sp<SkPicture> picture = recorder.finishRecordingAsPicture();
+     getPaintController().appendDebugDrawingAfterCommit(*this, picture, offsetFromLayoutObjectWithSubpixelAccumulation());
+ }
+ 
+diff --git a/third_party/WebKit/Source/platform/graphics/GraphicsLayer.h b/third_party/WebKit/Source/platform/graphics/GraphicsLayer.h
+index ef5f4744bedf091c24e0b620ae3c938eb0cd9648..aee462ad17de05dc4b1f7145018f22ccd14bd887 100644
+--- a/third_party/WebKit/Source/platform/graphics/GraphicsLayer.h
++++ b/third_party/WebKit/Source/platform/graphics/GraphicsLayer.h
+@@ -50,6 +50,7 @@
+ #include "public/platform/WebImageLayer.h"
+ #include "public/platform/WebLayerScrollClient.h"
+ #include "third_party/skia/include/core/SkFilterQuality.h"
++#include "third_party/skia/include/core/SkRefCnt.h"
+ #include "wtf/Vector.h"
+ #include <memory>
+ 
+@@ -299,7 +300,7 @@ private:
+     std::unique_ptr<JSONObject> layerTreeAsJSONInternal(LayerTreeFlags, RenderingContextMap&) const;
+ 
+ #if DCHECK_IS_ON()
+-    PassRefPtr<SkPicture> capturePicture();
++    sk_sp<SkPicture> capturePicture();
+     void checkPaintUnderInvalidations(const SkPicture&);
+ #endif
+ 
+diff --git a/third_party/WebKit/Source/platform/graphics/Image.cpp b/third_party/WebKit/Source/platform/graphics/Image.cpp
+index 5f58a9dda15df03d72cf4faddc879b75cf458e38..962fd2a506e6037c72ef5923b62b655342cc5eff 100644
+--- a/third_party/WebKit/Source/platform/graphics/Image.cpp
++++ b/third_party/WebKit/Source/platform/graphics/Image.cpp
+@@ -205,7 +205,7 @@ void Image::drawPattern(GraphicsContext& context, const FloatRect& floatSrcRect,
+ {
+     TRACE_EVENT0("skia", "Image::drawPattern");
+ 
+-    RefPtr<SkImage> image = imageForCurrentFrame();
++    sk_sp<SkImage> image = imageForCurrentFrame();
+     if (!image)
+         return;
+ 
+@@ -231,7 +231,7 @@ void Image::drawPattern(GraphicsContext& context, const FloatRect& floatSrcRect,
+     // Fetch this now as subsetting may swap the image.
+     auto imageID = image->uniqueID();
+ 
+-    image = fromSkSp(image->makeSubset(enclosingIntRect(normSrcRect)));
++    image = image->makeSubset(enclosingIntRect(normSrcRect));
+     if (!image)
+         return;
+ 
+@@ -259,14 +259,14 @@ PassRefPtr<Image> Image::imageForDefaultFrame()
+ 
+ bool Image::isTextureBacked()
+ {
+-    RefPtr<SkImage> image = imageForCurrentFrame();
++    sk_sp<SkImage> image = imageForCurrentFrame();
+     return image ? image->isTextureBacked() : false;
+ }
+ 
+ bool Image::applyShader(SkPaint& paint, const SkMatrix& localMatrix)
+ {
+     // Default shader impl: attempt to build a shader based on the current frame SkImage.
+-    RefPtr<SkImage> image = imageForCurrentFrame();
++    sk_sp<SkImage> image = imageForCurrentFrame();
+     if (!image)
+         return false;
+ 
+diff --git a/third_party/WebKit/Source/platform/graphics/Image.h b/third_party/WebKit/Source/platform/graphics/Image.h
+index ee10fe1121c75b0f894a6d142d950e2c8faf2370..173502d076901f78386771acdf3bb87b0fe29383 100644
+--- a/third_party/WebKit/Source/platform/graphics/Image.h
++++ b/third_party/WebKit/Source/platform/graphics/Image.h
+@@ -35,6 +35,7 @@
+ #include "platform/graphics/ImageAnimationPolicy.h"
+ #include "platform/graphics/ImageObserver.h"
+ #include "platform/graphics/ImageOrientation.h"
++#include "third_party/skia/include/core/SkRefCnt.h"
+ #include "wtf/Assertions.h"
+ #include "wtf/Noncopyable.h"
+ #include "wtf/PassRefPtr.h"
+@@ -141,7 +142,7 @@ public:
+ 
+     enum TileRule { StretchTile, RoundTile, SpaceTile, RepeatTile };
+ 
+-    virtual PassRefPtr<SkImage> imageForCurrentFrame() = 0;
++    virtual sk_sp<SkImage> imageForCurrentFrame() = 0;
+     virtual PassRefPtr<Image> imageForDefaultFrame();
+ 
+     virtual void drawPattern(GraphicsContext&, const FloatRect&,
+diff --git a/third_party/WebKit/Source/platform/graphics/ImageBuffer.cpp b/third_party/WebKit/Source/platform/graphics/ImageBuffer.cpp
+index 58f3e9ad0f84f27e6bb4cde1697072792b707397..12bf550b0b8955d9c52f67d9bd775e0a8b2ee46f 100644
+--- a/third_party/WebKit/Source/platform/graphics/ImageBuffer.cpp
++++ b/third_party/WebKit/Source/platform/graphics/ImageBuffer.cpp
+@@ -183,7 +183,7 @@ void ImageBuffer::resetCanvas(SkCanvas* canvas) const
+         m_client->restoreCanvasMatrixClipStack(canvas);
+ }
+ 
+-PassRefPtr<SkImage> ImageBuffer::newSkImageSnapshot(AccelerationHint hint, SnapshotReason reason) const
++sk_sp<SkImage> ImageBuffer::newSkImageSnapshot(AccelerationHint hint, SnapshotReason reason) const
+ {
+     if (m_snapshotState == InitialSnapshotState)
+         m_snapshotState = DidAcquireSnapshot;
+@@ -195,10 +195,10 @@ PassRefPtr<SkImage> ImageBuffer::newSkImageSnapshot(AccelerationHint hint, Snaps
+ 
+ PassRefPtr<Image> ImageBuffer::newImageSnapshot(AccelerationHint hint, SnapshotReason reason) const
+ {
+-    RefPtr<SkImage> snapshot = newSkImageSnapshot(hint, reason);
++    sk_sp<SkImage> snapshot = newSkImageSnapshot(hint, reason);
+     if (!snapshot)
+         return nullptr;
+-    return StaticBitmapImage::create(snapshot);
++    return StaticBitmapImage::create(std::move(snapshot));
+ }
+ 
+ void ImageBuffer::didDraw(const FloatRect& rect) const
+@@ -221,7 +221,7 @@ bool ImageBuffer::copyToPlatformTexture(gpu::gles2::GLES2Interface* gl, GLuint t
+     if (!isSurfaceValid())
+         return false;
+ 
+-    RefPtr<const SkImage> textureImage = m_surface->newImageSnapshot(PreferAcceleration, SnapshotReasonCopyToWebGLTexture);
++    sk_sp<const SkImage> textureImage = m_surface->newImageSnapshot(PreferAcceleration, SnapshotReasonCopyToWebGLTexture);
+     if (!textureImage)
+         return false;
+ 
+@@ -343,7 +343,7 @@ bool ImageBuffer::getImageData(Multiply multiplied, const IntRect& rect, WTF::Ar
+     if (ExpensiveCanvasHeuristicParameters::GetImageDataForcesNoAcceleration && !RuntimeEnabledFeatures::canvas2dFixedRenderingModeEnabled())
+         const_cast<ImageBuffer*>(this)->disableAcceleration();
+ 
+-    RefPtr<SkImage> snapshot = m_surface->newImageSnapshot(PreferNoAcceleration, SnapshotReasonGetImageData);
++    sk_sp<SkImage> snapshot = m_surface->newImageSnapshot(PreferNoAcceleration, SnapshotReasonGetImageData);
+     if (!snapshot)
+         return false;
+ 
+diff --git a/third_party/WebKit/Source/platform/graphics/ImageBuffer.h b/third_party/WebKit/Source/platform/graphics/ImageBuffer.h
+index 88ecc0c8f5e27508c9503f6bfc04ade06dc34cca..5c242667fbdd50b0268c3b1a521cade9519f5c5c 100644
+--- a/third_party/WebKit/Source/platform/graphics/ImageBuffer.h
++++ b/third_party/WebKit/Source/platform/graphics/ImageBuffer.h
+@@ -38,6 +38,7 @@
+ #include "platform/transforms/AffineTransform.h"
+ #include "third_party/skia/include/core/SkPaint.h"
+ #include "third_party/skia/include/core/SkPicture.h"
++#include "third_party/skia/include/core/SkRefCnt.h"
+ #include "wtf/Forward.h"
+ #include "wtf/PassRefPtr.h"
+ #include "wtf/Vector.h"
+@@ -135,10 +136,10 @@ public:
+ 
+     void notifySurfaceInvalid();
+ 
+-    PassRefPtr<SkImage> newSkImageSnapshot(AccelerationHint, SnapshotReason) const;
++    sk_sp<SkImage> newSkImageSnapshot(AccelerationHint, SnapshotReason) const;
+     PassRefPtr<Image> newImageSnapshot(AccelerationHint = PreferNoAcceleration, SnapshotReason = SnapshotReasonUnknown) const;
+ 
+-    PassRefPtr<SkPicture> getPicture() { return m_surface->getPicture(); }
++    sk_sp<SkPicture> getPicture() { return m_surface->getPicture(); }
+ 
+     void draw(GraphicsContext&, const FloatRect&, const FloatRect*, SkXfermode::Mode);
+ 
+diff --git a/third_party/WebKit/Source/platform/graphics/ImageBufferSurface.cpp b/third_party/WebKit/Source/platform/graphics/ImageBufferSurface.cpp
+index 9826aff936a790f3a9071564af9f11bbeca9bbb7..9c21fb4a4f23a1424021930aba9d8d3d890cc278 100644
+--- a/third_party/WebKit/Source/platform/graphics/ImageBufferSurface.cpp
++++ b/third_party/WebKit/Source/platform/graphics/ImageBufferSurface.cpp
+@@ -50,7 +50,7 @@ ImageBufferSurface::ImageBufferSurface(const IntSize& size, OpacityMode opacityM
+ 
+ ImageBufferSurface::~ImageBufferSurface() { }
+ 
+-PassRefPtr<SkPicture> ImageBufferSurface::getPicture()
++sk_sp<SkPicture> ImageBufferSurface::getPicture()
+ {
+     return nullptr;
+ }
+@@ -72,11 +72,11 @@ void ImageBufferSurface::clear()
+ 
+ void ImageBufferSurface::draw(GraphicsContext& context, const FloatRect& destRect, const FloatRect& srcRect, SkXfermode::Mode op)
+ {
+-    RefPtr<SkImage> snapshot = newImageSnapshot(PreferNoAcceleration, SnapshotReasonPaint);
++    sk_sp<SkImage> snapshot = newImageSnapshot(PreferNoAcceleration, SnapshotReasonPaint);
+     if (!snapshot)
+         return;
+ 
+-    RefPtr<Image> image = StaticBitmapImage::create(snapshot.release());
++    RefPtr<Image> image = StaticBitmapImage::create(std::move(snapshot));
+     context.drawImage(image.get(), destRect, &srcRect, op);
+ }
+ 
+diff --git a/third_party/WebKit/Source/platform/graphics/ImageBufferSurface.h b/third_party/WebKit/Source/platform/graphics/ImageBufferSurface.h
+index 4ef9d84089bc7a35a5e4eb9cd041c9786ad7490d..ad4a74a64d0b799cf12cf971691a0a30a9d42767 100644
+--- a/third_party/WebKit/Source/platform/graphics/ImageBufferSurface.h
++++ b/third_party/WebKit/Source/platform/graphics/ImageBufferSurface.h
+@@ -36,9 +36,9 @@
+ #include "platform/graphics/GraphicsTypes.h"
+ #include "third_party/khronos/GLES2/gl2.h"
+ #include "third_party/skia/include/core/SkPaint.h"
++#include "third_party/skia/include/core/SkRefCnt.h"
+ #include "wtf/Allocator.h"
+ #include "wtf/Noncopyable.h"
+-#include "wtf/PassRefPtr.h"
+ 
+ class SkBitmap;
+ class SkCanvas;
+@@ -72,7 +72,7 @@ public:
+     virtual void setFilterQuality(SkFilterQuality) { }
+     virtual void setIsHidden(bool) { }
+     virtual void setImageBuffer(ImageBuffer*) { }
+-    virtual PassRefPtr<SkPicture> getPicture();
++    virtual sk_sp<SkPicture> getPicture();
+     virtual void finalizeFrame(const FloatRect &dirtyRect) { }
+     virtual void draw(GraphicsContext&, const FloatRect& destRect, const FloatRect& srcRect, SkXfermode::Mode);
+     virtual void setHasExpensiveOp() { }
+@@ -83,7 +83,7 @@ public:
+     virtual bool writePixels(const SkImageInfo& origInfo, const void* pixels, size_t rowBytes, int x, int y);
+ 
+     // May return nullptr if the surface is GPU-backed and the GPU context was lost.
+-    virtual PassRefPtr<SkImage> newImageSnapshot(AccelerationHint, SnapshotReason) = 0;
++    virtual sk_sp<SkImage> newImageSnapshot(AccelerationHint, SnapshotReason) = 0;
+ 
+     OpacityMode getOpacityMode() const { return m_opacityMode; }
+     const IntSize& size() const { return m_size; }
+diff --git a/third_party/WebKit/Source/platform/graphics/ImageFrameGenerator.cpp b/third_party/WebKit/Source/platform/graphics/ImageFrameGenerator.cpp
+index ffb0daf7326dd4142480950dca6d3121403bca5a..60292c6ac26c0d97ad4f97e8b81e716550108352 100644
+--- a/third_party/WebKit/Source/platform/graphics/ImageFrameGenerator.cpp
++++ b/third_party/WebKit/Source/platform/graphics/ImageFrameGenerator.cpp
+@@ -131,7 +131,7 @@ bool ImageFrameGenerator::decodeAndScale(SegmentReader* data, bool allDataReceiv
+     ASSERT(m_fullSize == scaledSize);
+ 
+     // TODO (scroggo): Convert tryToResumeDecode() and decode() to take a
+-    // PassRefPtr<SkBitmap::Allocator> instead of a bare pointer.
++    // sk_sp<SkBitmap::Allocator> instead of a bare pointer.
+     SkBitmap bitmap = tryToResumeDecode(data, allDataReceived, index, scaledSize, externalAllocator.get());
+     if (bitmap.isNull())
+         return false;
+diff --git a/third_party/WebKit/Source/platform/graphics/ImageLayerChromiumTest.cpp b/third_party/WebKit/Source/platform/graphics/ImageLayerChromiumTest.cpp
+index ac6c74bc8e6b662d9faf579b9b90e62330a4afb2..ccb34c89aa5a224062c8e66b3479166c11941c1f 100644
+--- a/third_party/WebKit/Source/platform/graphics/ImageLayerChromiumTest.cpp
++++ b/third_party/WebKit/Source/platform/graphics/ImageLayerChromiumTest.cpp
+@@ -54,7 +54,7 @@ public:
+         return m_size;
+     }
+ 
+-    PassRefPtr<SkImage> imageForCurrentFrame() override
++    sk_sp<SkImage> imageForCurrentFrame() override
+     {
+         return m_image;
+     }
+@@ -79,7 +79,7 @@ private:
+             return;
+ 
+         surface->getCanvas()->clear(SK_ColorTRANSPARENT);
+-        m_image = fromSkSp(surface->makeImageSnapshot());
++        m_image = surface->makeImageSnapshot();
+     }
+ 
+     static sk_sp<SkSurface> createSkSurface(IntSize size, bool opaque)
+@@ -88,7 +88,7 @@ private:
+     }
+ 
+     IntSize m_size;
+-    RefPtr<SkImage> m_image;
++    sk_sp<SkImage> m_image;
+ };
+ 
+ } // anonymous namespace
+diff --git a/third_party/WebKit/Source/platform/graphics/ImagePattern.cpp b/third_party/WebKit/Source/platform/graphics/ImagePattern.cpp
+index e2aca3c21915dd6459c79fbd7d2df531ab672a1a..a76cd7f5a1fcbc6792348d88016ff7e14923c7a4 100644
+--- a/third_party/WebKit/Source/platform/graphics/ImagePattern.cpp
++++ b/third_party/WebKit/Source/platform/graphics/ImagePattern.cpp
+@@ -20,7 +20,7 @@ PassRefPtr<ImagePattern> ImagePattern::create(PassRefPtr<Image> image, RepeatMod
+ 
+ ImagePattern::ImagePattern(PassRefPtr<Image> image, RepeatMode repeatMode)
+     : Pattern(repeatMode)
+-    , m_tileImage(toSkSp(image->imageForCurrentFrame()))
++    , m_tileImage(image->imageForCurrentFrame())
+ {
+     m_previousLocalMatrix.setIdentity();
+     if (m_tileImage) {
+diff --git a/third_party/WebKit/Source/platform/graphics/ImageSource.cpp b/third_party/WebKit/Source/platform/graphics/ImageSource.cpp
+index af677889fd789baf92d0d7bef58f28ab5f52c2ed..bb459577276bb6208c8336f7f0aa9b1e413c40ac 100644
+--- a/third_party/WebKit/Source/platform/graphics/ImageSource.cpp
++++ b/third_party/WebKit/Source/platform/graphics/ImageSource.cpp
+@@ -115,7 +115,7 @@ size_t ImageSource::frameCount() const
+     return m_decoder ? m_decoder->frameCount() : 0;
+ }
+ 
+-PassRefPtr<SkImage> ImageSource::createFrameAtIndex(size_t index)
++sk_sp<SkImage> ImageSource::createFrameAtIndex(size_t index)
+ {
+     if (!m_decoder)
+         return nullptr;
+diff --git a/third_party/WebKit/Source/platform/graphics/ImageSource.h b/third_party/WebKit/Source/platform/graphics/ImageSource.h
+index 7bcfd9366225444b7325e178855484a381774116..e09cbe1651111f3cbb859deca136e6661aae98b3 100644
+--- a/third_party/WebKit/Source/platform/graphics/ImageSource.h
++++ b/third_party/WebKit/Source/platform/graphics/ImageSource.h
+@@ -29,6 +29,7 @@
+ #include "platform/PlatformExport.h"
+ #include "platform/graphics/DeferredImageDecoder.h"
+ #include "platform/graphics/ImageOrientation.h"
++#include "third_party/skia/include/core/SkRefCnt.h"
+ #include "wtf/Forward.h"
+ #include "wtf/Noncopyable.h"
+ #include <memory>
+@@ -85,7 +86,7 @@ public:
+     size_t frameCount() const;
+ 
+     // Attempts to create the requested frame.
+-    PassRefPtr<SkImage> createFrameAtIndex(size_t);
++    sk_sp<SkImage> createFrameAtIndex(size_t);
+ 
+     float frameDurationAtIndex(size_t) const;
+     bool frameHasAlphaAtIndex(size_t) const; // Whether or not the frame actually used any alpha.
+diff --git a/third_party/WebKit/Source/platform/graphics/LoggingCanvas.cpp b/third_party/WebKit/Source/platform/graphics/LoggingCanvas.cpp
+index da2801801e688735932b30b100799b3e59914b64..dc1ca86b1d2b6f8d36694b377efc9af6e2325c53 100644
+--- a/third_party/WebKit/Source/platform/graphics/LoggingCanvas.cpp
++++ b/third_party/WebKit/Source/platform/graphics/LoggingCanvas.cpp
+@@ -244,7 +244,7 @@ std::unique_ptr<JSONObject> objectForBitmapData(const SkBitmap& bitmap)
+ {
+     Vector<unsigned char> output;
+ 
+-    if (RefPtr<SkImage> image = fromSkSp(SkImage::MakeFromBitmap(bitmap))) {
++    if (sk_sp<SkImage> image = SkImage::MakeFromBitmap(bitmap)) {
+         ImagePixelLocker pixelLocker(image, kUnpremul_SkAlphaType, kRGBA_8888_SkColorType);
+         ImageDataBuffer imageData(IntSize(image->width(), image->height()),
+             static_cast<const unsigned char*>(pixelLocker.pixels()));
+diff --git a/third_party/WebKit/Source/platform/graphics/PaintGeneratedImage.h b/third_party/WebKit/Source/platform/graphics/PaintGeneratedImage.h
+index 58f55fd42b5edd82e6eee03ba7c7caeefa3d31d4..478335338a93640ba0a96dc905e9fc4a806c0065 100644
+--- a/third_party/WebKit/Source/platform/graphics/PaintGeneratedImage.h
++++ b/third_party/WebKit/Source/platform/graphics/PaintGeneratedImage.h
+@@ -7,6 +7,7 @@
+ 
+ #include "platform/geometry/IntSize.h"
+ #include "platform/graphics/GeneratedImage.h"
++#include "third_party/skia/include/core/SkRefCnt.h"
+ 
+ class SkPicture;
+ 
+@@ -14,9 +15,9 @@ namespace blink {
+ 
+ class PLATFORM_EXPORT PaintGeneratedImage : public GeneratedImage {
+ public:
+-    static PassRefPtr<PaintGeneratedImage> create(PassRefPtr<SkPicture> picture, const IntSize& size)
++    static PassRefPtr<PaintGeneratedImage> create(sk_sp<SkPicture> picture, const IntSize& size)
+     {
+-        return adoptRef(new PaintGeneratedImage(picture, size));
++        return adoptRef(new PaintGeneratedImage(std::move(picture), size));
+     }
+     ~PaintGeneratedImage() override { }
+ 
+@@ -24,13 +25,13 @@ protected:
+     void draw(SkCanvas*, const SkPaint&, const FloatRect&, const FloatRect&, RespectImageOrientationEnum, ImageClampingMode) override;
+     void drawTile(GraphicsContext&, const FloatRect&) final;
+ 
+-    PaintGeneratedImage(PassRefPtr<SkPicture> picture, const IntSize& size)
++    PaintGeneratedImage(sk_sp<SkPicture> picture, const IntSize& size)
+         : GeneratedImage(size)
+-        , m_picture(picture)
++        , m_picture(std::move(picture))
+     {
+     }
+ 
+-    RefPtr<SkPicture> m_picture;
++    sk_sp<SkPicture> m_picture;
+ };
+ 
+ } // namespace blink
+diff --git a/third_party/WebKit/Source/platform/graphics/Pattern.cpp b/third_party/WebKit/Source/platform/graphics/Pattern.cpp
+index 23fef80cbf3f8cbbbb9b866520aa7bafb4eb813f..63ae9480acb8b76a75a115e0cae3a258cad873f2 100644
+--- a/third_party/WebKit/Source/platform/graphics/Pattern.cpp
++++ b/third_party/WebKit/Source/platform/graphics/Pattern.cpp
+@@ -42,10 +42,10 @@ PassRefPtr<Pattern> Pattern::createImagePattern(PassRefPtr<Image> tileImage, Rep
+     return ImagePattern::create(tileImage, repeatMode);
+ }
+ 
+-PassRefPtr<Pattern> Pattern::createPicturePattern(PassRefPtr<SkPicture> picture,
++PassRefPtr<Pattern> Pattern::createPicturePattern(sk_sp<SkPicture> picture,
+     RepeatMode repeatMode)
+ {
+-    return PicturePattern::create(picture, repeatMode);
++    return PicturePattern::create(std::move(picture), repeatMode);
+ }
+ 
+ Pattern::Pattern(RepeatMode repeatMode, int64_t externalMemoryAllocated)
+diff --git a/third_party/WebKit/Source/platform/graphics/Pattern.h b/third_party/WebKit/Source/platform/graphics/Pattern.h
+index eac2ce9f5aec14d9f3d4233a291eb9d35800b690..acff69ed3796f8fa6395c660aacace6273d9e5ef 100644
+--- a/third_party/WebKit/Source/platform/graphics/Pattern.h
++++ b/third_party/WebKit/Source/platform/graphics/Pattern.h
+@@ -55,7 +55,7 @@ public:
+     };
+ 
+     static PassRefPtr<Pattern> createImagePattern(PassRefPtr<Image>, RepeatMode = RepeatModeXY);
+-    static PassRefPtr<Pattern> createPicturePattern(PassRefPtr<SkPicture>,
++    static PassRefPtr<Pattern> createPicturePattern(sk_sp<SkPicture>,
+         RepeatMode = RepeatModeXY);
+     virtual ~Pattern();
+ 
+diff --git a/third_party/WebKit/Source/platform/graphics/PicturePattern.cpp b/third_party/WebKit/Source/platform/graphics/PicturePattern.cpp
+index eb79de6de8bdc138794e912a4060db5d9e0862cc..8450112d54da256004a04b7b4aafecde3387a449 100644
+--- a/third_party/WebKit/Source/platform/graphics/PicturePattern.cpp
++++ b/third_party/WebKit/Source/platform/graphics/PicturePattern.cpp
+@@ -10,15 +10,15 @@
+ 
+ namespace blink {
+ 
+-PassRefPtr<PicturePattern> PicturePattern::create(PassRefPtr<SkPicture> picture,
++PassRefPtr<PicturePattern> PicturePattern::create(sk_sp<SkPicture> picture,
+     RepeatMode repeatMode)
+ {
+-    return adoptRef(new PicturePattern(picture, repeatMode));
++    return adoptRef(new PicturePattern(std::move(picture), repeatMode));
+ }
+ 
+-PicturePattern::PicturePattern(PassRefPtr<SkPicture> picture, RepeatMode mode)
++PicturePattern::PicturePattern(sk_sp<SkPicture> picture, RepeatMode mode)
+     : Pattern(mode)
+-    , m_tilePicture(toSkSp(picture))
++    , m_tilePicture(std::move(picture))
+ {
+     // All current clients use RepeatModeXY, so we only support this mode for now.
+     ASSERT(isRepeatXY());
+diff --git a/third_party/WebKit/Source/platform/graphics/PicturePattern.h b/third_party/WebKit/Source/platform/graphics/PicturePattern.h
+index 5c666a31ab133d7dbd030e0756902a70f087cfd4..04c071c018e57e0fb4471c31a703ea171a8ef0b5 100644
+--- a/third_party/WebKit/Source/platform/graphics/PicturePattern.h
++++ b/third_party/WebKit/Source/platform/graphics/PicturePattern.h
+@@ -6,12 +6,13 @@
+ #define PicturePattern_h
+ 
+ #include "platform/graphics/Pattern.h"
++#include "third_party/skia/include/core/SkRefCnt.h"
+ 
+ namespace blink {
+ 
+ class PLATFORM_EXPORT PicturePattern final : public Pattern {
+ public:
+-    static PassRefPtr<PicturePattern> create(PassRefPtr<SkPicture>, RepeatMode);
++    static PassRefPtr<PicturePattern> create(sk_sp<SkPicture>, RepeatMode);
+ 
+     ~PicturePattern() override;
+ 
+@@ -19,7 +20,7 @@ protected:
+     sk_sp<SkShader> createShader(const SkMatrix&) override;
+ 
+ private:
+-    PicturePattern(PassRefPtr<SkPicture>, RepeatMode);
++    PicturePattern(sk_sp<SkPicture>, RepeatMode);
+ 
+     sk_sp<SkPicture> m_tilePicture;
+ };
+diff --git a/third_party/WebKit/Source/platform/graphics/PictureSnapshot.cpp b/third_party/WebKit/Source/platform/graphics/PictureSnapshot.cpp
+index c9fa7320db496293edb802643f51e506da718de3..c8a74212b52746b9d3f7dcd04f8c301f4642b872 100644
+--- a/third_party/WebKit/Source/platform/graphics/PictureSnapshot.cpp
++++ b/third_party/WebKit/Source/platform/graphics/PictureSnapshot.cpp
+@@ -42,6 +42,7 @@
+ #include "platform/image-encoders/PNGImageEncoder.h"
+ #include "third_party/skia/include/core/SkData.h"
+ #include "third_party/skia/include/core/SkImage.h"
++#include "third_party/skia/include/core/SkImageDeserializer.h"
+ #include "third_party/skia/include/core/SkPictureRecorder.h"
+ #include "third_party/skia/include/core/SkStream.h"
+ #include "wtf/CurrentTime.h"
+@@ -53,26 +54,30 @@
+ 
+ namespace blink {
+ 
+-PictureSnapshot::PictureSnapshot(PassRefPtr<const SkPicture> picture)
+-    : m_picture(picture)
++PictureSnapshot::PictureSnapshot(sk_sp<const SkPicture> picture)
++    : m_picture(std::move(picture))
+ {
+ }
+ 
+-static bool decodeBitmap(const void* data, size_t length, SkBitmap* result)
+-{
+-    // No need to copy the data; this decodes immediately.
+-    RefPtr<SegmentReader> segmentReader = SegmentReader::createFromSkData(SkData::MakeWithoutCopy(data, length));
+-    std::unique_ptr<ImageDecoder> imageDecoder = ImageDecoder::create(segmentReader.release(), true,
+-        ImageDecoder::AlphaPremultiplied, ImageDecoder::GammaAndColorProfileIgnored);
+-    if (!imageDecoder)
+-        return false;
+-
+-    ImageFrame* frame = imageDecoder->frameBufferAtIndex(0);
+-    if (!frame)
+-        return true;
+-    *result = frame->bitmap();
+-    return true;
+-}
++class SkiaImageDecoder : public SkImageDeserializer {
++public:
++    sk_sp<SkImage> makeFromMemory(const void* data, size_t length, const SkIRect* subset) override
++    {
++        // No need to copy the data; this decodes immediately.
++        RefPtr<SegmentReader> segmentReader = SegmentReader::createFromSkData(SkData::MakeWithoutCopy(data, length));
++        std::unique_ptr<ImageDecoder> imageDecoder = ImageDecoder::create(segmentReader.release(), true,
++            ImageDecoder::AlphaPremultiplied, ImageDecoder::GammaAndColorProfileIgnored);
++        if (!imageDecoder)
++            return nullptr;
++
++        ImageFrame* frame = imageDecoder->frameBufferAtIndex(0);
++        return (frame && !imageDecoder->failed()) ? frame->finalizePixelsAndGetImage() : nullptr;
++    }
++    sk_sp<SkImage> makeFromData(SkData* data, const SkIRect* subset) override
++    {
++        return this->makeFromMemory(data->data(), data->size(), subset);
++    }
++};
+ 
+ PassRefPtr<PictureSnapshot> PictureSnapshot::load(const Vector<RefPtr<TilePictureStream>>& tiles)
+ {
+@@ -82,7 +87,8 @@ PassRefPtr<PictureSnapshot> PictureSnapshot::load(const Vector<RefPtr<TilePictur
+     FloatRect unionRect;
+     for (const auto& tileStream : tiles) {
+         SkMemoryStream stream(tileStream->data.begin(), tileStream->data.size());
+-        sk_sp<SkPicture> picture = SkPicture::MakeFromStream(&stream, decodeBitmap);
++        SkiaImageDecoder factory;
++        sk_sp<SkPicture> picture = SkPicture::MakeFromStream(&stream, &factory);
+         if (!picture)
+             return nullptr;
+         FloatRect cullRect(picture->cullRect());
+@@ -91,7 +97,7 @@ PassRefPtr<PictureSnapshot> PictureSnapshot::load(const Vector<RefPtr<TilePictur
+         pictures.append(std::move(picture));
+     }
+     if (tiles.size() == 1)
+-        return adoptRef(new PictureSnapshot(fromSkSp(std::move(pictures[0]))));
++        return adoptRef(new PictureSnapshot(std::move(pictures[0])));
+     SkPictureRecorder recorder;
+     SkCanvas* canvas = recorder.beginRecording(unionRect.width(), unionRect.height(), 0, 0);
+     for (size_t i = 0; i < pictures.size(); ++i) {
+@@ -100,7 +106,7 @@ PassRefPtr<PictureSnapshot> PictureSnapshot::load(const Vector<RefPtr<TilePictur
+         pictures[i]->playback(canvas, 0);
+         canvas->restore();
+     }
+-    return adoptRef(new PictureSnapshot(fromSkSp(recorder.finishRecordingAsPicture())));
++    return adoptRef(new PictureSnapshot(recorder.finishRecordingAsPicture()));
+ }
+ 
+ bool PictureSnapshot::isEmpty() const
+@@ -131,7 +137,7 @@ std::unique_ptr<Vector<char>> PictureSnapshot::replay(unsigned fromStep, unsigne
+     std::unique_ptr<Vector<char>> base64Data = wrapUnique(new Vector<char>());
+     Vector<char> encodedImage;
+ 
+-    RefPtr<SkImage> image = fromSkSp(SkImage::MakeFromBitmap(bitmap));
++    sk_sp<SkImage> image = SkImage::MakeFromBitmap(bitmap);
+     if (!image)
+         return nullptr;
+ 
+diff --git a/third_party/WebKit/Source/platform/graphics/PictureSnapshot.h b/third_party/WebKit/Source/platform/graphics/PictureSnapshot.h
+index 2ef4c195e7c8aa59c3461f1805c756b311c330b4..13a7d1fb2ea13b04df97e4f3559e2b8e04e8521a 100644
+--- a/third_party/WebKit/Source/platform/graphics/PictureSnapshot.h
++++ b/third_party/WebKit/Source/platform/graphics/PictureSnapshot.h
+@@ -36,6 +36,7 @@
+ #include "platform/graphics/GraphicsContext.h"
+ #include "third_party/skia/include/core/SkPicture.h"
+ #include "third_party/skia/include/core/SkPictureRecorder.h"
++#include "third_party/skia/include/core/SkRefCnt.h"
+ #include "wtf/RefCounted.h"
+ #include <memory>
+ 
+@@ -55,7 +56,7 @@ public:
+ 
+     static PassRefPtr<PictureSnapshot> load(const Vector<RefPtr<TilePictureStream>>&);
+ 
+-    PictureSnapshot(PassRefPtr<const SkPicture>);
++    PictureSnapshot(sk_sp<const SkPicture>);
+ 
+     std::unique_ptr<Vector<char>> replay(unsigned fromStep = 0, unsigned toStep = 0, double scale = 1.0) const;
+     std::unique_ptr<Timings> profile(unsigned minIterations, double minDuration, const FloatRect* clipRect) const;
+@@ -65,7 +66,7 @@ public:
+ private:
+     std::unique_ptr<SkBitmap> createBitmap() const;
+ 
+-    RefPtr<const SkPicture> m_picture;
++    sk_sp<const SkPicture> m_picture;
+ };
+ 
+ } // namespace blink
+diff --git a/third_party/WebKit/Source/platform/graphics/RecordingImageBufferSurface.cpp b/third_party/WebKit/Source/platform/graphics/RecordingImageBufferSurface.cpp
+index ce00f07a0d4c38b424b2cb6a86ad9eec6b184080..d0547e04385e3247968e6ad2823e1a46cbe81ea9 100644
+--- a/third_party/WebKit/Source/platform/graphics/RecordingImageBufferSurface.cpp
++++ b/third_party/WebKit/Source/platform/graphics/RecordingImageBufferSurface.cpp
+@@ -87,7 +87,7 @@ void RecordingImageBufferSurface::fallBackToRasterCanvas(FallbackReason reason)
+ 
+     if (m_previousFrame) {
+         m_previousFrame->playback(m_fallbackSurface->canvas());
+-        m_previousFrame.clear();
++        m_previousFrame.reset();
+     }
+ 
+     if (m_currentFrame) {
+@@ -136,7 +136,7 @@ static RecordingImageBufferSurface::FallbackReason snapshotReasonToFallbackReaso
+     return RecordingImageBufferSurface::FallbackReasonUnknown;
+ }
+ 
+-PassRefPtr<SkImage> RecordingImageBufferSurface::newImageSnapshot(AccelerationHint hint, SnapshotReason reason)
++sk_sp<SkImage> RecordingImageBufferSurface::newImageSnapshot(AccelerationHint hint, SnapshotReason reason)
+ {
+     if (!m_fallbackSurface)
+         fallBackToRasterCanvas(snapshotReasonToFallbackReason(reason));
+@@ -183,7 +183,7 @@ void RecordingImageBufferSurface::disableDeferral(DisableDeferralReason reason)
+         fallBackToRasterCanvas(disableDeferralReasonToFallbackReason(reason));
+ }
+ 
+-PassRefPtr<SkPicture> RecordingImageBufferSurface::getPicture()
++sk_sp<SkPicture> RecordingImageBufferSurface::getPicture()
+ {
+     if (m_fallbackSurface)
+         return nullptr;
+@@ -239,7 +239,7 @@ void RecordingImageBufferSurface::flush(FlushReason reason)
+ void RecordingImageBufferSurface::willOverwriteCanvas()
+ {
+     m_frameWasCleared = true;
+-    m_previousFrame.clear();
++    m_previousFrame.reset();
+     m_previousFrameHasExpensiveOp = false;
+     m_previousFramePixelCount = 0;
+     if (m_didRecordDrawCommandsInCurrentFrame) {
+@@ -267,7 +267,7 @@ bool RecordingImageBufferSurface::finalizeFrameInternal(FallbackReason* fallback
+     if (!m_imageBuffer->isDirty()) {
+         if (!m_previousFrame) {
+             // Create an initial blank frame
+-            m_previousFrame = fromSkSp(m_currentFrame->finishRecordingAsPicture());
++            m_previousFrame = m_currentFrame->finishRecordingAsPicture();
+             initializeCurrentFrame();
+         }
+         CHECK(m_currentFrame);
+@@ -284,7 +284,7 @@ bool RecordingImageBufferSurface::finalizeFrameInternal(FallbackReason* fallback
+         return false;
+     }
+ 
+-    m_previousFrame = fromSkSp(m_currentFrame->finishRecordingAsPicture());
++    m_previousFrame = m_currentFrame->finishRecordingAsPicture();
+     m_previousFrameHasExpensiveOp = m_currentFrameHasExpensiveOp;
+     m_previousFramePixelCount = m_currentFramePixelCount;
+     initializeCurrentFrame();
+@@ -300,9 +300,9 @@ void RecordingImageBufferSurface::draw(GraphicsContext& context, const FloatRect
+         return;
+     }
+ 
+-    RefPtr<SkPicture> picture = getPicture();
++    sk_sp<SkPicture> picture = getPicture();
+     if (picture) {
+-        context.compositePicture(picture.get(), destRect, srcRect, op);
++        context.compositePicture(std::move(picture), destRect, srcRect, op);
+     } else {
+         ImageBufferSurface::draw(context, destRect, srcRect, op);
+     }
+diff --git a/third_party/WebKit/Source/platform/graphics/RecordingImageBufferSurface.h b/third_party/WebKit/Source/platform/graphics/RecordingImageBufferSurface.h
+index 43b5dcf8e4475c9464ff9621da4089de4931156b..6b0935f390c6249ebdcd3a113f7db16a92777251 100644
+--- a/third_party/WebKit/Source/platform/graphics/RecordingImageBufferSurface.h
++++ b/third_party/WebKit/Source/platform/graphics/RecordingImageBufferSurface.h
+@@ -8,9 +8,9 @@
+ #include "platform/graphics/GraphicsContext.h"
+ #include "platform/graphics/ImageBufferSurface.h"
+ #include "public/platform/WebThread.h"
++#include "third_party/skia/include/core/SkRefCnt.h"
+ #include "wtf/Allocator.h"
+ #include "wtf/Noncopyable.h"
+-#include "wtf/RefPtr.h"
+ #include <memory>
+ 
+ class SkCanvas;
+@@ -45,7 +45,7 @@ public:
+     // Implementation of ImageBufferSurface interfaces
+     SkCanvas* canvas() override;
+     void disableDeferral(DisableDeferralReason) override;
+-    PassRefPtr<SkPicture> getPicture() override;
++    sk_sp<SkPicture> getPicture() override;
+     void flush(FlushReason) override;
+     void didDraw(const FloatRect&) override;
+     bool isValid() const override { return true; }
+@@ -54,7 +54,7 @@ public:
+     void willOverwriteCanvas() override;
+     virtual void finalizeFrame(const FloatRect&);
+     void setImageBuffer(ImageBuffer*) override;
+-    PassRefPtr<SkImage> newImageSnapshot(AccelerationHint, SnapshotReason) override;
++    sk_sp<SkImage> newImageSnapshot(AccelerationHint, SnapshotReason) override;
+     void draw(GraphicsContext&, const FloatRect& destRect, const FloatRect& srcRect, SkXfermode::Mode) override;
+     bool isExpensiveToPaint() override;
+     void setHasExpensiveOp() override { m_currentFrameHasExpensiveOp = true; }
+@@ -101,7 +101,7 @@ private:
+     int approximateOpCount();
+ 
+     std::unique_ptr<SkPictureRecorder> m_currentFrame;
+-    RefPtr<SkPicture> m_previousFrame;
++    sk_sp<SkPicture> m_previousFrame;
+     std::unique_ptr<ImageBufferSurface> m_fallbackSurface;
+     ImageBuffer* m_imageBuffer;
+     int m_initialSaveCount;
+diff --git a/third_party/WebKit/Source/platform/graphics/RecordingImageBufferSurfaceTest.cpp b/third_party/WebKit/Source/platform/graphics/RecordingImageBufferSurfaceTest.cpp
+index e22914e9a181d0035045c1175ea535c398d16dc0..22e61d3c077bf1280601aea5435a3c3ad5b5bbc3 100644
+--- a/third_party/WebKit/Source/platform/graphics/RecordingImageBufferSurfaceTest.cpp
++++ b/third_party/WebKit/Source/platform/graphics/RecordingImageBufferSurfaceTest.cpp
+@@ -113,7 +113,7 @@ public:
+     void testEmptyPicture()
+     {
+         m_testSurface->initializeCurrentFrame();
+-        RefPtr<SkPicture> picture = m_testSurface->getPicture();
++        sk_sp<SkPicture> picture = m_testSurface->getPicture();
+         EXPECT_TRUE((bool)picture.get());
+         EXPECT_EQ(1, m_fakeImageBufferClient->frameCount());
+         expectDisplayListEnabled(true);
+diff --git a/third_party/WebKit/Source/platform/graphics/StaticBitmapImage.cpp b/third_party/WebKit/Source/platform/graphics/StaticBitmapImage.cpp
+index 8b3ac0036c07c034f4a559db768f7ffe65ad7fef..187f3271ae8884e4b2a71c1df85d57568b719c17 100644
+--- a/third_party/WebKit/Source/platform/graphics/StaticBitmapImage.cpp
++++ b/third_party/WebKit/Source/platform/graphics/StaticBitmapImage.cpp
+@@ -15,16 +15,16 @@
+ 
+ namespace blink {
+ 
+-PassRefPtr<StaticBitmapImage> StaticBitmapImage::create(PassRefPtr<SkImage> image)
++PassRefPtr<StaticBitmapImage> StaticBitmapImage::create(sk_sp<SkImage> image)
+ {
+     if (!image)
+         return nullptr;
+     if (image->isTextureBacked())
+-        return AcceleratedStaticBitmapImage::create(image);
+-    return adoptRef(new StaticBitmapImage(image));
++        return AcceleratedStaticBitmapImage::create(std::move(image));
++    return adoptRef(new StaticBitmapImage(std::move(image)));
+ }
+ 
+-StaticBitmapImage::StaticBitmapImage(PassRefPtr<SkImage> image) : m_image(image)
++StaticBitmapImage::StaticBitmapImage(sk_sp<SkImage> image) : m_image(std::move(image))
+ {
+     ASSERT(m_image);
+ }
+@@ -60,7 +60,7 @@ void StaticBitmapImage::draw(SkCanvas* canvas, const SkPaint& paint, const Float
+         observer->didDraw(this);
+ }
+ 
+-PassRefPtr<SkImage> StaticBitmapImage::imageForCurrentFrame()
++sk_sp<SkImage> StaticBitmapImage::imageForCurrentFrame()
+ {
+     return m_image;
+ }
+diff --git a/third_party/WebKit/Source/platform/graphics/StaticBitmapImage.h b/third_party/WebKit/Source/platform/graphics/StaticBitmapImage.h
+index 21caac78ae27094dd64736795bb1e8dc6d519fdd..398aeadfb3178b704185f07e0b054998f17793fb 100644
+--- a/third_party/WebKit/Source/platform/graphics/StaticBitmapImage.h
++++ b/third_party/WebKit/Source/platform/graphics/StaticBitmapImage.h
+@@ -7,6 +7,7 @@
+ 
+ #include "platform/graphics/Image.h"
+ #include "third_party/khronos/GLES2/gl2.h"
++#include "third_party/skia/include/core/SkRefCnt.h"
+ 
+ namespace blink {
+ 
+@@ -18,13 +19,13 @@ public:
+ 
+     bool currentFrameIsComplete() override { return true; }
+ 
+-    static PassRefPtr<StaticBitmapImage> create(PassRefPtr<SkImage>);
++    static PassRefPtr<StaticBitmapImage> create(sk_sp<SkImage>);
+     void destroyDecodedData() override { }
+     bool currentFrameKnownToBeOpaque(MetadataMode = UseCurrentMetadata) override;
+     IntSize size() const override;
+     void draw(SkCanvas*, const SkPaint&, const FloatRect& dstRect, const FloatRect& srcRect, RespectImageOrientationEnum, ImageClampingMode) override;
+ 
+-    PassRefPtr<SkImage> imageForCurrentFrame() override;
++    sk_sp<SkImage> imageForCurrentFrame() override;
+ 
+     bool originClean() const { return m_isOriginClean; }
+     void setOriginClean(bool flag) { m_isOriginClean = flag; }
+@@ -35,9 +36,9 @@ public:
+     virtual bool hasMailbox() { return false; }
+ 
+ protected:
+-    StaticBitmapImage(PassRefPtr<SkImage>);
++    StaticBitmapImage(sk_sp<SkImage>);
+     StaticBitmapImage() { } // empty constructor for derived class.
+-    RefPtr<SkImage> m_image;
++    sk_sp<SkImage> m_image;
+ 
+ private:
+     bool m_isOriginClean = true;
+diff --git a/third_party/WebKit/Source/platform/graphics/UnacceleratedImageBufferSurface.cpp b/third_party/WebKit/Source/platform/graphics/UnacceleratedImageBufferSurface.cpp
+index 66d467232f11db2dca2176f649027400e2d08b71..4b4b81a84533d3b116569176ac056d5ae055c64c 100644
+--- a/third_party/WebKit/Source/platform/graphics/UnacceleratedImageBufferSurface.cpp
++++ b/third_party/WebKit/Source/platform/graphics/UnacceleratedImageBufferSurface.cpp
+@@ -64,9 +64,9 @@ bool UnacceleratedImageBufferSurface::isValid() const
+     return m_surface;
+ }
+ 
+-PassRefPtr<SkImage> UnacceleratedImageBufferSurface::newImageSnapshot(AccelerationHint, SnapshotReason)
++sk_sp<SkImage> UnacceleratedImageBufferSurface::newImageSnapshot(AccelerationHint, SnapshotReason)
+ {
+-    return fromSkSp(m_surface->makeImageSnapshot());
++    return m_surface->makeImageSnapshot();
+ }
+ 
+ } // namespace blink
+diff --git a/third_party/WebKit/Source/platform/graphics/UnacceleratedImageBufferSurface.h b/third_party/WebKit/Source/platform/graphics/UnacceleratedImageBufferSurface.h
+index 8bd2acd181c6acb0c2c70b7635f00436b20e9d7f..f38859ca0e6831ff45b8b8fb5fcfadc0f0a615b4 100644
+--- a/third_party/WebKit/Source/platform/graphics/UnacceleratedImageBufferSurface.h
++++ b/third_party/WebKit/Source/platform/graphics/UnacceleratedImageBufferSurface.h
+@@ -32,7 +32,7 @@
+ #define UnacceleratedImageBufferSurface_h
+ 
+ #include "platform/graphics/ImageBufferSurface.h"
+-#include "wtf/RefPtr.h"
++#include "third_party/skia/include/core/SkRefCnt.h"
+ 
+ class SkSurface;
+ 
+@@ -47,7 +47,7 @@ public:
+     SkCanvas* canvas() override;
+     bool isValid() const override;
+ 
+-    PassRefPtr<SkImage> newImageSnapshot(AccelerationHint, SnapshotReason) override;
++    sk_sp<SkImage> newImageSnapshot(AccelerationHint, SnapshotReason) override;
+ private:
+     sk_sp<SkSurface> m_surface;
+ };
+diff --git a/third_party/WebKit/Source/platform/graphics/filters/SkiaImageFilterBuilder.cpp b/third_party/WebKit/Source/platform/graphics/filters/SkiaImageFilterBuilder.cpp
+index 7dcf75ef895cb1a2730b5676f5686e96e1edd339..b27a44b2817b8230db06441dec7b98671f8b2857 100644
+--- a/third_party/WebKit/Source/platform/graphics/filters/SkiaImageFilterBuilder.cpp
++++ b/third_party/WebKit/Source/platform/graphics/filters/SkiaImageFilterBuilder.cpp
+@@ -87,7 +87,7 @@ sk_sp<SkImageFilter> build(FilterEffect* effect, ColorSpace colorSpace, bool des
+ 
+ sk_sp<SkImageFilter> transformColorSpace(sk_sp<SkImageFilter> input, ColorSpace srcColorSpace, ColorSpace dstColorSpace)
+ {
+-    sk_sp<SkColorFilter> colorFilter = toSkSp(ColorSpaceUtilities::createColorSpaceFilter(srcColorSpace, dstColorSpace));
++    sk_sp<SkColorFilter> colorFilter = ColorSpaceUtilities::createColorSpaceFilter(srcColorSpace, dstColorSpace);
+     if (!colorFilter)
+         return input;
+ 
+diff --git a/third_party/WebKit/Source/platform/graphics/gpu/AcceleratedImageBufferSurface.cpp b/third_party/WebKit/Source/platform/graphics/gpu/AcceleratedImageBufferSurface.cpp
+index 8339235e3de007d2c1d649a03a1d214230a51bb1..f27638f7aef834f7366574b1e21f9b64b8a78930 100644
+--- a/third_party/WebKit/Source/platform/graphics/gpu/AcceleratedImageBufferSurface.cpp
++++ b/third_party/WebKit/Source/platform/graphics/gpu/AcceleratedImageBufferSurface.cpp
+@@ -60,9 +60,9 @@ AcceleratedImageBufferSurface::AcceleratedImageBufferSurface(const IntSize& size
+     clear();
+ }
+ 
+-PassRefPtr<SkImage> AcceleratedImageBufferSurface::newImageSnapshot(AccelerationHint, SnapshotReason)
++sk_sp<SkImage> AcceleratedImageBufferSurface::newImageSnapshot(AccelerationHint, SnapshotReason)
+ {
+-    return fromSkSp(m_surface->makeImageSnapshot());
++    return m_surface->makeImageSnapshot();
+ }
+ 
+ GLuint AcceleratedImageBufferSurface::getBackingTextureHandleForOverwrite()
+diff --git a/third_party/WebKit/Source/platform/graphics/gpu/AcceleratedImageBufferSurface.h b/third_party/WebKit/Source/platform/graphics/gpu/AcceleratedImageBufferSurface.h
+index dc1163f82d1c2b3fdc94faa78e1642ea5da4eed3..ca8fd5709fa6cd72104bb9303e3d4dcac829aa3d 100644
+--- a/third_party/WebKit/Source/platform/graphics/gpu/AcceleratedImageBufferSurface.h
++++ b/third_party/WebKit/Source/platform/graphics/gpu/AcceleratedImageBufferSurface.h
+@@ -33,6 +33,7 @@
+ 
+ #include "platform/graphics/ImageBufferSurface.h"
+ #include "public/platform/WebGraphicsContext3DProvider.h"
++#include "third_party/skia/include/core/SkRefCnt.h"
+ #include "third_party/skia/include/core/SkSurface.h"
+ #include <memory>
+ 
+@@ -47,7 +48,7 @@ public:
+     SkCanvas* canvas() override { return m_surface ? m_surface->getCanvas() : nullptr; }
+     bool isValid() const override { return m_surface; }
+     bool isAccelerated() const override { return true; }
+-    PassRefPtr<SkImage> newImageSnapshot(AccelerationHint, SnapshotReason) override;
++    sk_sp<SkImage> newImageSnapshot(AccelerationHint, SnapshotReason) override;
+     GLuint getBackingTextureHandleForOverwrite() override;
+ 
+ private:
+diff --git a/third_party/WebKit/Source/platform/graphics/gpu/DrawingBuffer.cpp b/third_party/WebKit/Source/platform/graphics/gpu/DrawingBuffer.cpp
+index c51ee8052242eaafdd7631f1a180de4b27eee4d1..d07a78e79cd8679d020d58ee57eef6880c003b88 100644
+--- a/third_party/WebKit/Source/platform/graphics/gpu/DrawingBuffer.cpp
++++ b/third_party/WebKit/Source/platform/graphics/gpu/DrawingBuffer.cpp
+@@ -430,7 +430,7 @@ PassRefPtr<StaticBitmapImage> DrawingBuffer::transferToStaticBitmapImage()
+         // If we can't get a mailbox, return an transparent black ImageBitmap.
+         // The only situation this could happen is when two or more calls to transferToImageBitmap are made back-to-back, or when the context gets lost.
+         sk_sp<SkSurface> surface = SkSurface::MakeRasterN32Premul(m_size.width(), m_size.height());
+-        return StaticBitmapImage::create(fromSkSp(surface->makeImageSnapshot()));
++        return StaticBitmapImage::create(surface->makeImageSnapshot());
+     }
+ 
+     DCHECK_EQ(m_size.width(), textureMailbox.size_in_pixels().width());
+@@ -473,7 +473,7 @@ PassRefPtr<StaticBitmapImage> DrawingBuffer::transferToStaticBitmapImage()
+ 
+     // TODO(xidachen): Create a small pool of recycled textures from ImageBitmapRenderingContext's
+     // transferFromImageBitmap, and try to use them in DrawingBuffer.
+-    return AcceleratedStaticBitmapImage::create(fromSkSp(skImage), grContextRef, skImageMailbox, skImageSyncToken);
++    return AcceleratedStaticBitmapImage::create(std::move(skImage), grContextRef, skImageMailbox, skImageSyncToken);
+ }
+ 
+ DrawingBuffer::TextureParameters DrawingBuffer::chromiumImageTextureParameters()
+diff --git a/third_party/WebKit/Source/platform/graphics/gpu/WebGLImageConversion.cpp b/third_party/WebKit/Source/platform/graphics/gpu/WebGLImageConversion.cpp
+index dd201db7ec2f7a9db99914a50233c31bbbe4735c..fc4ebbdd6230ea1d537b05c91dd7576558658e6d 100644
+--- a/third_party/WebKit/Source/platform/graphics/gpu/WebGLImageConversion.cpp
++++ b/third_party/WebKit/Source/platform/graphics/gpu/WebGLImageConversion.cpp
+@@ -1928,7 +1928,6 @@ bool frameIsValid(const SkBitmap& frameBitmap)
+ {
+     return !frameBitmap.isNull()
+         && !frameBitmap.empty()
+-        && frameBitmap.isImmutable()
+         && frameBitmap.colorType() == kN32_SkColorType;
+ }
+ 
+@@ -2132,7 +2131,7 @@ void WebGLImageConversion::ImageExtractor::extractImage(bool premultiplyAlpha, b
+     if (!m_image)
+         return;
+ 
+-    RefPtr<SkImage> skiaImage = m_image->imageForCurrentFrame();
++    sk_sp<SkImage> skiaImage = m_image->imageForCurrentFrame();
+     SkImageInfo info = skiaImage
+         ? SkImageInfo::MakeN32Premul(m_image->width(), m_image->height())
+         : SkImageInfo::MakeUnknown();
+@@ -2154,11 +2153,10 @@ void WebGLImageConversion::ImageExtractor::extractImage(bool premultiplyAlpha, b
+         if (!frameIsValid(bitmap))
+             return;
+ 
+-        // TODO(fmalita): Partial frames are not supported currently: frameIsValid ensures that
+-        // only immutable/fully decoded frames make it through.  We could potentially relax this
+-        // and allow SkImage::NewFromBitmap to make a copy.
+-        ASSERT(bitmap.isImmutable());
+-        skiaImage = fromSkSp(SkImage::MakeFromBitmap(bitmap));
++        // TODO(fmalita): Partial frames are not supported currently: only fully
++        // decoded frames make it through.  We could potentially relax this and
++        // use SkImage::MakeFromBitmap(bitmap) to make a copy.
++        skiaImage = frame->finalizePixelsAndGetImage();
+         info = bitmap.info();
+ 
+         if (hasAlpha && premultiplyAlpha)
+@@ -2186,7 +2184,7 @@ void WebGLImageConversion::ImageExtractor::extractImage(bool premultiplyAlpha, b
+     if (m_imageWidth != (unsigned)m_image->width() || m_imageHeight != (unsigned)m_image->height())
+         return;
+ 
+-    m_imagePixelLocker.emplace(skiaImage, info.alphaType(), kN32_SkColorType);
++    m_imagePixelLocker.emplace(std::move(skiaImage), info.alphaType(), kN32_SkColorType);
+ }
+ 
+ unsigned WebGLImageConversion::getChannelBitsByFormat(GLenum format)
+diff --git a/third_party/WebKit/Source/platform/graphics/paint/DisplayItemListTest.cpp b/third_party/WebKit/Source/platform/graphics/paint/DisplayItemListTest.cpp
+index eceb235483dff2678917a497c042891f91728e53..82dd12ccca1888c9a9565859ba09ee6f2920c8a3 100644
+--- a/third_party/WebKit/Source/platform/graphics/paint/DisplayItemListTest.cpp
++++ b/third_party/WebKit/Source/platform/graphics/paint/DisplayItemListTest.cpp
+@@ -35,13 +35,13 @@ public:
+     FakeDisplayItemClient m_client;
+ };
+ 
+-static PassRefPtr<SkPicture> createRectPicture(const IntRect& bounds)
++static sk_sp<SkPicture> createRectPicture(const IntRect& bounds)
+ {
+     SkPictureRecorder recorder;
+     SkCanvas* canvas = recorder.beginRecording(bounds.width(), bounds.height());
+     canvas->drawRect(SkRect::MakeXYWH(bounds.x(), bounds.y(), bounds.width(), bounds.height()),
+         SkPaint());
+-    return fromSkSp(recorder.finishRecordingAsPicture());
++    return recorder.finishRecordingAsPicture();
+ }
+ 
+ TEST_F(DisplayItemListTest, AppendVisualRect_Simple)
+diff --git a/third_party/WebKit/Source/platform/graphics/paint/DrawingDisplayItem.cpp b/third_party/WebKit/Source/platform/graphics/paint/DrawingDisplayItem.cpp
+index 9d8ceb88b10617e0ed40e22265763f4de827aa01..439ea79110737dd9d04dc5efe4140bffb3b5f485 100644
+--- a/third_party/WebKit/Source/platform/graphics/paint/DrawingDisplayItem.cpp
++++ b/third_party/WebKit/Source/platform/graphics/paint/DrawingDisplayItem.cpp
+@@ -26,7 +26,7 @@ void DrawingDisplayItem::replay(GraphicsContext& context) const
+ void DrawingDisplayItem::appendToWebDisplayItemList(const IntRect& visualRect, WebDisplayItemList* list) const
+ {
+     if (m_picture)
+-        list->appendDrawingItem(visualRect, toSkSp(m_picture));
++        list->appendDrawingItem(visualRect, m_picture);
+ }
+ 
+ bool DrawingDisplayItem::drawsContent() const
+@@ -64,8 +64,8 @@ static bool picturesEqual(const SkPicture* picture1, const SkPicture* picture2)
+     if (picture1Serialized.bytesWritten() != picture2Serialized.bytesWritten())
+         return false;
+ 
+-    RefPtr<SkData> data1 = adoptRef(picture1Serialized.copyToData());
+-    RefPtr<SkData> data2 = adoptRef(picture2Serialized.copyToData());
++    sk_sp<SkData> data1(picture1Serialized.copyToData());
++    sk_sp<SkData> data2(picture2Serialized.copyToData());
+     return data1->equals(data2.get());
+ }
+ 
+diff --git a/third_party/WebKit/Source/platform/graphics/paint/DrawingDisplayItem.h b/third_party/WebKit/Source/platform/graphics/paint/DrawingDisplayItem.h
+index 310a9739994f8f9a10ab2ec0998cafd0d8ace289..306b6e00127ad94dd7df689402d4e586646ecbed 100644
+--- a/third_party/WebKit/Source/platform/graphics/paint/DrawingDisplayItem.h
++++ b/third_party/WebKit/Source/platform/graphics/paint/DrawingDisplayItem.h
+@@ -10,12 +10,13 @@
+ #include "platform/geometry/FloatPoint.h"
+ #include "platform/graphics/paint/DisplayItem.h"
+ #include "third_party/skia/include/core/SkPicture.h"
++#include "third_party/skia/include/core/SkRefCnt.h"
+ 
+ namespace blink {
+ 
+ class PLATFORM_EXPORT DrawingDisplayItem final : public DisplayItem {
+ public:
+-    DrawingDisplayItem(const DisplayItemClient& client, Type type, PassRefPtr<const SkPicture> picture, bool knownToBeOpaque = false)
++    DrawingDisplayItem(const DisplayItemClient& client, Type type, sk_sp<const SkPicture> picture, bool knownToBeOpaque = false)
+         : DisplayItem(client, type, sizeof(*this))
+         , m_picture(picture && picture->approximateOpCount() ? picture : nullptr)
+         , m_knownToBeOpaque(knownToBeOpaque)
+@@ -42,7 +43,7 @@ private:
+     void dumpPropertiesAsDebugString(WTF::StringBuilder&) const override;
+ #endif
+ 
+-    RefPtr<const SkPicture> m_picture;
++    sk_sp<const SkPicture> m_picture;
+ 
+     // True if there are no transparent areas. Only used for SlimmingPaintV2.
+     const bool m_knownToBeOpaque;
+diff --git a/third_party/WebKit/Source/platform/graphics/paint/PaintController.cpp b/third_party/WebKit/Source/platform/graphics/paint/PaintController.cpp
+index cde9a3c99881117026576217ac7b733d00d121e9..035f37df893ce946a1c560788f29c05223af00da 100644
+--- a/third_party/WebKit/Source/platform/graphics/paint/PaintController.cpp
++++ b/third_party/WebKit/Source/platform/graphics/paint/PaintController.cpp
+@@ -508,10 +508,10 @@ size_t PaintController::approximateUnsharedMemoryUsage() const
+     return memoryUsage;
+ }
+ 
+-void PaintController::appendDebugDrawingAfterCommit(const DisplayItemClient& displayItemClient, PassRefPtr<SkPicture> picture, const LayoutSize& offsetFromLayoutObject)
++void PaintController::appendDebugDrawingAfterCommit(const DisplayItemClient& displayItemClient, sk_sp<SkPicture> picture, const LayoutSize& offsetFromLayoutObject)
+ {
+     DCHECK(m_newDisplayItemList.isEmpty());
+-    DrawingDisplayItem& displayItem = m_currentPaintArtifact.getDisplayItemList().allocateAndConstruct<DrawingDisplayItem>(displayItemClient, DisplayItem::DebugDrawing, picture);
++    DrawingDisplayItem& displayItem = m_currentPaintArtifact.getDisplayItemList().allocateAndConstruct<DrawingDisplayItem>(displayItemClient, DisplayItem::DebugDrawing, std::move(picture));
+     displayItem.setSkippedCache();
+     // TODO(wkorman): Only compute and append visual rect for drawings.
+     m_currentPaintArtifact.getDisplayItemList().appendVisualRect(visualRectForDisplayItem(displayItem, offsetFromLayoutObject));
+diff --git a/third_party/WebKit/Source/platform/graphics/paint/PaintController.h b/third_party/WebKit/Source/platform/graphics/paint/PaintController.h
+index f8bdca0902c29308456d86b51ee45bea2389a579..5bf793aed5a114fe229075f4e96fce988b4ebf8c 100644
+--- a/third_party/WebKit/Source/platform/graphics/paint/PaintController.h
++++ b/third_party/WebKit/Source/platform/graphics/paint/PaintController.h
+@@ -16,6 +16,7 @@
+ #include "platform/graphics/paint/PaintChunk.h"
+ #include "platform/graphics/paint/PaintChunker.h"
+ #include "platform/graphics/paint/Transform3DDisplayItem.h"
++#include "third_party/skia/include/core/SkRefCnt.h"
+ #include "wtf/Alignment.h"
+ #include "wtf/Assertions.h"
+ #include "wtf/HashMap.h"
+@@ -147,7 +148,7 @@ public:
+     // the last commitNewDisplayItems(). Use with care.
+     DisplayItemList& newDisplayItemList() { return m_newDisplayItemList; }
+ 
+-    void appendDebugDrawingAfterCommit(const DisplayItemClient&, PassRefPtr<SkPicture>, const LayoutSize& offsetFromLayoutObject);
++    void appendDebugDrawingAfterCommit(const DisplayItemClient&, sk_sp<SkPicture>, const LayoutSize& offsetFromLayoutObject);
+ 
+     void showDebugData() const;
+ 
+diff --git a/third_party/WebKit/Source/platform/graphics/paint/PaintControllerTest.cpp b/third_party/WebKit/Source/platform/graphics/paint/PaintControllerTest.cpp
+index 0d4787ec947134bb20e84452e0e4ef041d6fdfc2..c0eb43bc93bb81b19849dd50da43687e9ffcbb9d 100644
+--- a/third_party/WebKit/Source/platform/graphics/paint/PaintControllerTest.cpp
++++ b/third_party/WebKit/Source/platform/graphics/paint/PaintControllerTest.cpp
+@@ -826,8 +826,8 @@ TEST_F_OR_P(PaintControllerTest, SkipCache)
+         TestDisplayItem(multicol, backgroundDrawingType),
+         TestDisplayItem(content, foregroundDrawingType),
+         TestDisplayItem(content, foregroundDrawingType));
+-    RefPtr<const SkPicture> picture1 = static_cast<const DrawingDisplayItem&>(getPaintController().getDisplayItemList()[1]).picture();
+-    RefPtr<const SkPicture> picture2 = static_cast<const DrawingDisplayItem&>(getPaintController().getDisplayItemList()[2]).picture();
++    sk_sp<const SkPicture> picture1 = sk_ref_sp(static_cast<const DrawingDisplayItem&>(getPaintController().getDisplayItemList()[1]).picture());
++    sk_sp<const SkPicture> picture2 = sk_ref_sp(static_cast<const DrawingDisplayItem&>(getPaintController().getDisplayItemList()[2]).picture());
+     EXPECT_NE(picture1, picture2);
+ 
+     // Draw again with nothing invalidated.
+@@ -852,8 +852,8 @@ TEST_F_OR_P(PaintControllerTest, SkipCache)
+         TestDisplayItem(multicol, backgroundDrawingType),
+         TestDisplayItem(content, foregroundDrawingType),
+         TestDisplayItem(content, foregroundDrawingType));
+-    EXPECT_NE(picture1, static_cast<const DrawingDisplayItem&>(getPaintController().getDisplayItemList()[1]).picture());
+-    EXPECT_NE(picture2, static_cast<const DrawingDisplayItem&>(getPaintController().getDisplayItemList()[2]).picture());
++    EXPECT_NE(picture1.get(), static_cast<const DrawingDisplayItem&>(getPaintController().getDisplayItemList()[1]).picture());
++    EXPECT_NE(picture2.get(), static_cast<const DrawingDisplayItem&>(getPaintController().getDisplayItemList()[2]).picture());
+ 
+     // Now the multicol becomes 3 columns and repaints.
+     multicol.setDisplayItemsUncached();
+@@ -871,8 +871,8 @@ TEST_F_OR_P(PaintControllerTest, SkipCache)
+         TestDisplayItem(content, foregroundDrawingType),
+         TestDisplayItem(content, foregroundDrawingType),
+         TestDisplayItem(content, foregroundDrawingType));
+-    EXPECT_NE(picture1, static_cast<const DrawingDisplayItem&>(getPaintController().newDisplayItemList()[1]).picture());
+-    EXPECT_NE(picture2, static_cast<const DrawingDisplayItem&>(getPaintController().newDisplayItemList()[2]).picture());
++    EXPECT_NE(picture1.get(), static_cast<const DrawingDisplayItem&>(getPaintController().newDisplayItemList()[1]).picture());
++    EXPECT_NE(picture2.get(), static_cast<const DrawingDisplayItem&>(getPaintController().newDisplayItemList()[2]).picture());
+ 
+     getPaintController().commitNewDisplayItems();
+ }
+@@ -898,9 +898,9 @@ TEST_F_OR_P(PaintControllerTest, PartialSkipCache)
+         TestDisplayItem(content, backgroundDrawingType),
+         TestDisplayItem(content, foregroundDrawingType),
+         TestDisplayItem(content, foregroundDrawingType));
+-    RefPtr<const SkPicture> picture0 = static_cast<const DrawingDisplayItem&>(getPaintController().getDisplayItemList()[0]).picture();
+-    RefPtr<const SkPicture> picture1 = static_cast<const DrawingDisplayItem&>(getPaintController().getDisplayItemList()[1]).picture();
+-    RefPtr<const SkPicture> picture2 = static_cast<const DrawingDisplayItem&>(getPaintController().getDisplayItemList()[2]).picture();
++    sk_sp<const SkPicture> picture0 = sk_ref_sp(static_cast<const DrawingDisplayItem&>(getPaintController().getDisplayItemList()[0]).picture());
++    sk_sp<const SkPicture> picture1 = sk_ref_sp(static_cast<const DrawingDisplayItem&>(getPaintController().getDisplayItemList()[1]).picture());
++    sk_sp<const SkPicture> picture2 = sk_ref_sp(static_cast<const DrawingDisplayItem&>(getPaintController().getDisplayItemList()[2]).picture());
+     EXPECT_NE(picture1, picture2);
+ 
+     // Content's cache is invalid because it has display items skipped cache.
+@@ -927,9 +927,9 @@ TEST_F_OR_P(PaintControllerTest, PartialSkipCache)
+         TestDisplayItem(content, backgroundDrawingType),
+         TestDisplayItem(content, foregroundDrawingType),
+         TestDisplayItem(content, foregroundDrawingType));
+-    EXPECT_NE(picture0, static_cast<const DrawingDisplayItem&>(getPaintController().getDisplayItemList()[0]).picture());
+-    EXPECT_NE(picture1, static_cast<const DrawingDisplayItem&>(getPaintController().getDisplayItemList()[1]).picture());
+-    EXPECT_NE(picture2, static_cast<const DrawingDisplayItem&>(getPaintController().getDisplayItemList()[2]).picture());
++    EXPECT_NE(picture0.get(), static_cast<const DrawingDisplayItem&>(getPaintController().getDisplayItemList()[0]).picture());
++    EXPECT_NE(picture1.get(), static_cast<const DrawingDisplayItem&>(getPaintController().getDisplayItemList()[1]).picture());
++    EXPECT_NE(picture2.get(), static_cast<const DrawingDisplayItem&>(getPaintController().getDisplayItemList()[2]).picture());
+ }
+ 
+ TEST_F_OR_P(PaintControllerTest, OptimizeNoopPairs)
+diff --git a/third_party/WebKit/Source/platform/graphics/paint/SkPictureBuilder.cpp b/third_party/WebKit/Source/platform/graphics/paint/SkPictureBuilder.cpp
+index 2d8215d5774b9da21fbdf7c724edcc20d57da57c..916ec4a2165e2d4eb6b465a5f9b92293098f38f8 100644
+--- a/third_party/WebKit/Source/platform/graphics/paint/SkPictureBuilder.cpp
++++ b/third_party/WebKit/Source/platform/graphics/paint/SkPictureBuilder.cpp
+@@ -30,7 +30,7 @@ SkPictureBuilder::SkPictureBuilder(const FloatRect& bounds, SkMetaData* metaData
+ 
+ SkPictureBuilder::~SkPictureBuilder() {}
+ 
+-PassRefPtr<SkPicture> SkPictureBuilder::endRecording()
++sk_sp<SkPicture> SkPictureBuilder::endRecording()
+ {
+     m_context->beginRecording(m_bounds);
+     m_paintController->endSkippingCache();
+diff --git a/third_party/WebKit/Source/platform/graphics/paint/SkPictureBuilder.h b/third_party/WebKit/Source/platform/graphics/paint/SkPictureBuilder.h
+index 1455f8e63fa45020efca3661ba1e52d3b5c2892d..d653b5ff62b7d9c74e5b3c0ecdf790a9b0a2101b 100644
+--- a/third_party/WebKit/Source/platform/graphics/paint/SkPictureBuilder.h
++++ b/third_party/WebKit/Source/platform/graphics/paint/SkPictureBuilder.h
+@@ -8,8 +8,8 @@
+ #include "platform/PlatformExport.h"
+ #include "platform/geometry/FloatRect.h"
+ #include "platform/graphics/paint/DisplayItemClient.h"
++#include "third_party/skia/include/core/SkRefCnt.h"
+ #include "wtf/Noncopyable.h"
+-#include "wtf/PassRefPtr.h"
+ #include <memory>
+ 
+ class SkMetaData;
+@@ -36,7 +36,7 @@ public:
+ 
+     // Returns a picture capturing all drawing performed on the builder's context since
+     // construction.
+-    PassRefPtr<SkPicture> endRecording();
++    sk_sp<SkPicture> endRecording();
+ 
+     // DisplayItemClient methods
+     String debugName() const final { return "SkPictureBuilder"; }
+diff --git a/third_party/WebKit/Source/platform/graphics/skia/ImagePixelLocker.cpp b/third_party/WebKit/Source/platform/graphics/skia/ImagePixelLocker.cpp
+index 70b051166858aab9099680f5b134da0c4d45fc92..569e25097b00e976bf41fe845a9123b7807545c4 100644
+--- a/third_party/WebKit/Source/platform/graphics/skia/ImagePixelLocker.cpp
++++ b/third_party/WebKit/Source/platform/graphics/skia/ImagePixelLocker.cpp
+@@ -24,9 +24,9 @@ bool infoIsCompatible(const SkImageInfo& info, SkAlphaType alphaType, SkColorTyp
+ 
+ } // anonymous namespace
+ 
+-ImagePixelLocker::ImagePixelLocker(PassRefPtr<const SkImage> image, SkAlphaType alphaType,
++ImagePixelLocker::ImagePixelLocker(sk_sp<const SkImage> image, SkAlphaType alphaType,
+     SkColorType colorType)
+-    : m_image(image)
++    : m_image(std::move(image))
+ {
+     // If the image has in-RAM pixels and their format matches, use them directly.
+     // TODO(fmalita): All current clients expect packed pixel rows.  Maybe we could update them
+diff --git a/third_party/WebKit/Source/platform/graphics/skia/ImagePixelLocker.h b/third_party/WebKit/Source/platform/graphics/skia/ImagePixelLocker.h
+index e3b8bc319760e318597a55f9c05719c64acf1f5c..1fd7646362708535f413810322e63a3d939a30be 100644
+--- a/third_party/WebKit/Source/platform/graphics/skia/ImagePixelLocker.h
++++ b/third_party/WebKit/Source/platform/graphics/skia/ImagePixelLocker.h
+@@ -7,6 +7,7 @@
+ 
+ #include "platform/heap/Heap.h"
+ #include "third_party/skia/include/core/SkImageInfo.h"
++#include "third_party/skia/include/core/SkRefCnt.h"
+ #include "wtf/Allocator.h"
+ #include "wtf/Noncopyable.h"
+ #include "wtf/PassRefPtr.h"
+@@ -20,12 +21,12 @@ class ImagePixelLocker final {
+     DISALLOW_NEW_EXCEPT_PLACEMENT_NEW();
+     WTF_MAKE_NONCOPYABLE(ImagePixelLocker);
+ public:
+-    ImagePixelLocker(PassRefPtr<const SkImage>, SkAlphaType, SkColorType);
++    ImagePixelLocker(sk_sp<const SkImage>, SkAlphaType, SkColorType);
+ 
+     const void* pixels() const { return m_pixels; }
+ 
+ private:
+-    const RefPtr<const SkImage> m_image;
++    const sk_sp<const SkImage> m_image;
+     const void* m_pixels;
+     SkAutoMalloc m_pixelStorage;
+ };
+diff --git a/third_party/WebKit/Source/platform/graphics/skia/SkiaUtils.h b/third_party/WebKit/Source/platform/graphics/skia/SkiaUtils.h
+index 28028ae8e76574ec561b81be01e399ca2a015ade..223e0151e98c15f64cd2d9ab079438e8dbd09b1e 100644
+--- a/third_party/WebKit/Source/platform/graphics/skia/SkiaUtils.h
++++ b/third_party/WebKit/Source/platform/graphics/skia/SkiaUtils.h
+@@ -143,15 +143,6 @@ inline SkCanvas::SrcRectConstraint WebCoreClampingModeToSkiaRectConstraint(Image
+ }
+ 
+ // Skia's smart pointer APIs are preferable over their legacy raw pointer counterparts.
+-// The following helpers ensure interoperability between Skia's SkRefCnt wrapper sk_sp<T> and
+-// Blink's RefPtr<T>/PassRefPtr<T>.
+-//
+-//   - fromSkSp(sk_sp<T>):       adopts an sk_sp into a PassRefPtr (to be used when transferring
+-//                               ownership from Skia to Blink).
+-//   - toSkSp(PassRefPtr<T>):    releases a PassRefPtr into a sk_sp (to be used when transferring
+-//                               ownership from Blink to Skia).
+-//   - toSkSp(const RefPtr<T>&): shares a RefPtr as a new sk_sp (to be used when sharing
+-//                               ownership).
+ //
+ // General guidelines
+ //
+@@ -160,64 +151,30 @@ inline SkCanvas::SrcRectConstraint WebCoreClampingModeToSkiaRectConstraint(Image
+ //   1) use sk_sp-based Skia factories if available (e.g. SkShader::MakeFoo() instead of
+ //      SkShader::CreateFoo())
+ //
+-//   2) use sk_sp<T> locals for temporary objects (to be immediately transferred back to Skia)
+-//
+-//   3) use RefPtr<T>/PassRefPtr<T> for objects to be retained in Blink, use
+-//      fromSkSp(sk_sp<T>) to convert
++//   2) use sk_sp<T> locals for all objects
+ //
+ // When passing ref counted objects to Skia:
+ //
+-//   1) use sk_sk-based Skia APIs when available (e.g. SkPaint::setShader(sk_sp<SkShader>)
++//   1) use sk_sp-based Skia APIs when available (e.g. SkPaint::setShader(sk_sp<SkShader>)
+ //      instead of SkPaint::setShader(SkShader*))
+ //
+-//   2) if the object ownership is being passed to Skia, use std::move(sk_sp<T>) or
+-//      toSkSp(PassRefPtr<T>) to transfer without refcount churn
+-//
+-//   3) if the object ownership is shared with Skia (Blink retains a reference), use
+-//      toSkSp(const RefPtr<T>&)
++//   2) if the object ownership is being passed to Skia, use std::move(sk_sp<T>)
+ //
+ // Example (creating a SkShader and setting it on SkPaint):
+ //
+-// a) legacy/old style
+-//
+-//     RefPtr<SkShader> shader = adoptRef(SkShader::CreateFoo(...));
+-//     paint.setShader(shader.get());
+-//
+-//  (Note: the legacy approach introduces refcount churn as Skia grabs a ref while Blink is
+-//   temporarily holding on to its own)
+-//
+-// b) new style, ownership transferred
++// a) ownership transferred
+ //
+ //     // using Skia smart pointer locals
+ //     sk_sp<SkShader> shader = SkShader::MakeFoo(...);
+ //     paint.setShader(std::move(shader));
+ //
+-//     // using Blink smart pointer locals
+-//     RefPtr<SkShader> shader = fromSkSp(SkShader::MakeFoo(...));
+-//     paint.setShader(toSkSp(shader.release());
+-//
+ //     // using no locals
+ //     paint.setShader(SkShader::MakeFoo(...));
+ //
+-// c) new style, shared ownership
++// b) shared ownership
+ //
+-//     RefPtr<SkShader> shader = fromSkSp(SkShader::MakeFoo(...));
+-//     paint.setShader(toSkSp(shader));
+-//
+-template <typename T> PassRefPtr<T> fromSkSp(sk_sp<T> sp)
+-{
+-    return adoptRef(sp.release());
+-}
+-
+-template <typename T> sk_sp<T> toSkSp(PassRefPtr<T> ref)
+-{
+-    return sk_sp<T>(ref.leakRef());
+-}
+-
+-template <typename T> sk_sp<T> toSkSp(const RefPtr<T>& ref)
+-{
+-    return toSkSp(PassRefPtr<T>(ref));
+-}
++//     sk_sp<SkShader> shader = SkShader::MakeFoo(...);
++//     paint.setShader(shader);
+ 
+ } // namespace blink
+ 
+diff --git a/third_party/WebKit/Source/platform/image-decoders/FastSharedBufferReaderTest.cpp b/third_party/WebKit/Source/platform/image-decoders/FastSharedBufferReaderTest.cpp
+index f18d5f8c47cff12a1b0a7ecc3211108b8c784b77..bf2181ad0b54ffd13a4a0eab79cc25fc2b2e1731 100644
+--- a/third_party/WebKit/Source/platform/image-decoders/FastSharedBufferReaderTest.cpp
++++ b/third_party/WebKit/Source/platform/image-decoders/FastSharedBufferReaderTest.cpp
+@@ -54,7 +54,7 @@ PassRefPtr<SegmentReader> copyToROBufferSegmentReader(PassRefPtr<SegmentReader>
+         rwBuffer.append(segment, length);
+         position += length;
+     }
+-    return SegmentReader::createFromSkROBuffer(adoptRef(rwBuffer.newRBufferSnapshot()));
++    return SegmentReader::createFromSkROBuffer(sk_sp<SkROBuffer>(rwBuffer.newRBufferSnapshot()));
+ }
+ 
+ PassRefPtr<SegmentReader> copyToDataSegmentReader(PassRefPtr<SegmentReader> input)
+@@ -216,7 +216,7 @@ TEST(SegmentReaderTest, variableSegments)
+         rwBuffer.append(referenceData + SharedBuffer::kSegmentSize, 2 * SharedBuffer::kSegmentSize);
+         rwBuffer.append(referenceData + 3 * SharedBuffer::kSegmentSize, .5 * SharedBuffer::kSegmentSize);
+ 
+-        segmentReader = SegmentReader::createFromSkROBuffer(adoptRef(rwBuffer.newRBufferSnapshot()));
++        segmentReader = SegmentReader::createFromSkROBuffer(sk_sp<SkROBuffer>(rwBuffer.newRBufferSnapshot()));
+     }
+ 
+     const char* segment;
+diff --git a/third_party/WebKit/Source/platform/image-decoders/ImageFrame.cpp b/third_party/WebKit/Source/platform/image-decoders/ImageFrame.cpp
+index 6a4db8fa2d711b56af64eac34f940d4fd870781b..07fd1d72bdc4af77a23c160b919c44694b182573 100644
+--- a/third_party/WebKit/Source/platform/image-decoders/ImageFrame.cpp
++++ b/third_party/WebKit/Source/platform/image-decoders/ImageFrame.cpp
+@@ -27,6 +27,7 @@
+ #include "platform/image-decoders/ImageFrame.h"
+ 
+ #include "platform/RuntimeEnabledFeatures.h"
++#include "platform/graphics/skia/SkiaUtils.h"
+ #include "platform/image-decoders/ImageDecoder.h"
+ 
+ namespace blink {
+@@ -88,14 +89,27 @@ void ImageFrame::zeroFillPixelData()
+ 
+ bool ImageFrame::copyBitmapData(const ImageFrame& other)
+ {
+-    if (this == &other)
+-        return true;
+-
++    DCHECK_NE(this, &other);
+     m_hasAlpha = other.m_hasAlpha;
+     m_bitmap.reset();
+     return other.m_bitmap.copyTo(&m_bitmap, other.m_bitmap.colorType());
+ }
+ 
++bool ImageFrame::takeBitmapDataIfWritable(ImageFrame* other)
++{
++    DCHECK(other);
++    DCHECK_EQ(FrameComplete, other->m_status);
++    DCHECK_EQ(FrameEmpty, m_status);
++    DCHECK_NE(this, other);
++    if (other->m_bitmap.isImmutable())
++        return false;
++    m_hasAlpha = other->m_hasAlpha;
++    m_bitmap.reset();
++    m_bitmap.swap(other->m_bitmap);
++    other->m_status = FrameEmpty;
++    return true;
++}
++
+ bool ImageFrame::setSizeAndColorProfile(int newWidth, int newHeight, const ICCProfile& newIccProfile)
+ {
+     // setSizeAndColorProfile() should only be called once, it leaks memory otherwise.
+@@ -119,6 +133,13 @@ bool ImageFrame::hasAlpha() const
+     return m_hasAlpha;
+ }
+ 
++sk_sp<SkImage> ImageFrame::finalizePixelsAndGetImage()
++{
++    DCHECK_EQ(FrameComplete, m_status);
++    m_bitmap.setImmutable();
++    return SkImage::MakeFromBitmap(m_bitmap);
++}
++
+ void ImageFrame::setHasAlpha(bool alpha)
+ {
+     m_hasAlpha = alpha;
+@@ -131,10 +152,13 @@ void ImageFrame::setStatus(Status status)
+     m_status = status;
+     if (m_status == FrameComplete) {
+         m_bitmap.setAlphaType(computeAlphaType());
+-        // Send pending pixels changed notifications now, because we can't do this after
+-        // the bitmap has been marked immutable.
++        // Send pending pixels changed notifications now, because we can't do
++        // this after the bitmap has been marked immutable.  We don't set the
++        // bitmap immutable here because it would defeat
++        // takeBitmapDataIfWritable().  Instead we let the bitmap stay mutable
++        // until someone calls finalizePixelsAndGetImage() to actually get the
++        // SkImage.
+         notifyBitmapIfPixelsChanged();
+-        m_bitmap.setImmutable(); // Tell the bitmap it's done.
+     }
+ }
+ 
+diff --git a/third_party/WebKit/Source/platform/image-decoders/ImageFrame.h b/third_party/WebKit/Source/platform/image-decoders/ImageFrame.h
+index 3541f7dcc1eef4f979dc05d574220a55a52d69d7..13f080231a89c77cbf9acbab8562868936c0ce0b 100644
+--- a/third_party/WebKit/Source/platform/image-decoders/ImageFrame.h
++++ b/third_party/WebKit/Source/platform/image-decoders/ImageFrame.h
+@@ -32,6 +32,7 @@
+ #include "public/platform/WebVector.h"
+ #include "third_party/skia/include/core/SkBitmap.h"
+ #include "third_party/skia/include/core/SkColorPriv.h"
++#include "third_party/skia/include/core/SkImage.h"
+ #include "wtf/Allocator.h"
+ #include "wtf/Assertions.h"
+ #include "wtf/PassRefPtr.h"
+@@ -97,6 +98,11 @@ public:
+     // the other.  Returns whether the copy succeeded.
+     bool copyBitmapData(const ImageFrame&);
+ 
++    // Moves the bitmap data from the provided frame to this one, leaving the
++    // provided frame empty.  Operation is successful only if bitmap data is not
++    // marked as done (immutable).  Returns whether the move succeeded.
++    bool takeBitmapDataIfWritable(ImageFrame*);
++
+     // Copies the pixel data at [(startX, startY), (endX, startY)) to the
+     // same X-coordinates on each subsequent row up to but not including
+     // endY.
+@@ -125,7 +131,15 @@ public:
+     AlphaBlendSource getAlphaBlendSource() const { return m_alphaBlendSource; }
+     bool premultiplyAlpha() const { return m_premultiplyAlpha; }
+     SkBitmap::Allocator* allocator() const { return m_allocator; }
++
++    // Returns the bitmap that is the output of decoding.
+     const SkBitmap& bitmap() const { return m_bitmap; }
++
++    // Create SkImage from bitmap() and return it.  This should be called only
++    // if frame is complete.  The bitmap is set immutable before creating
++    // SkImage to avoid copying bitmap in SkImage::MakeFromBitmap(m_bitmap).
++    sk_sp<SkImage> finalizePixelsAndGetImage();
++
+     // Returns true if the pixels changed, but the bitmap has not yet been notified.
+     bool pixelsChanged() const { return m_pixelsChanged; }
+     size_t requiredPreviousFrameIndex() const { return m_requiredPreviousFrameIndex; }
+diff --git a/third_party/WebKit/Source/platform/image-decoders/SegmentReader.cpp b/third_party/WebKit/Source/platform/image-decoders/SegmentReader.cpp
+index 89ac6d7432833c05e52138338c3476cfc4399c0c..63128de51c26833a8e42764110cc8c4f0bd18223 100644
+--- a/third_party/WebKit/Source/platform/image-decoders/SegmentReader.cpp
++++ b/third_party/WebKit/Source/platform/image-decoders/SegmentReader.cpp
+@@ -87,14 +87,14 @@ sk_sp<SkData> DataSegmentReader::getAsSkData() const
+ class ROBufferSegmentReader final : public SegmentReader {
+     WTF_MAKE_NONCOPYABLE(ROBufferSegmentReader);
+ public:
+-    ROBufferSegmentReader(PassRefPtr<SkROBuffer>);
++    ROBufferSegmentReader(sk_sp<SkROBuffer>);
+ 
+     size_t size() const override;
+     size_t getSomeData(const char*& data, size_t position) const override;
+     sk_sp<SkData> getAsSkData() const override;
+ 
+ private:
+-    RefPtr<SkROBuffer> m_roBuffer;
++    sk_sp<SkROBuffer> m_roBuffer;
+     // Protects access to mutable fields.
+     mutable Mutex m_readMutex;
+     // Position of the first char in the current block of m_iter.
+@@ -102,8 +102,8 @@ private:
+     mutable SkROBuffer::Iter m_iter;
+ };
+ 
+-ROBufferSegmentReader::ROBufferSegmentReader(PassRefPtr<SkROBuffer> buffer)
+-    : m_roBuffer(buffer)
++ROBufferSegmentReader::ROBufferSegmentReader(sk_sp<SkROBuffer> buffer)
++    : m_roBuffer(std::move(buffer))
+     , m_positionOfBlock(0)
+     , m_iter(m_roBuffer.get())
+     {}
+@@ -191,9 +191,9 @@ PassRefPtr<SegmentReader> SegmentReader::createFromSkData(sk_sp<SkData> data)
+     return adoptRef(new DataSegmentReader(std::move(data)));
+ }
+ 
+-PassRefPtr<SegmentReader> SegmentReader::createFromSkROBuffer(PassRefPtr<SkROBuffer> buffer)
++PassRefPtr<SegmentReader> SegmentReader::createFromSkROBuffer(sk_sp<SkROBuffer> buffer)
+ {
+-    return adoptRef(new ROBufferSegmentReader(buffer));
++    return adoptRef(new ROBufferSegmentReader(std::move(buffer)));
+ }
+ 
+ } // namespace blink
+diff --git a/third_party/WebKit/Source/platform/image-decoders/SegmentReader.h b/third_party/WebKit/Source/platform/image-decoders/SegmentReader.h
+index d76925402d80d36145cf4fe40fb88a747a0f3baf..307ebfa44fcd9bc045cd2cb58e639b9d75933828 100644
+--- a/third_party/WebKit/Source/platform/image-decoders/SegmentReader.h
++++ b/third_party/WebKit/Source/platform/image-decoders/SegmentReader.h
+@@ -8,6 +8,7 @@
+ #include "platform/SharedBuffer.h"
+ #include "third_party/skia/include/core/SkData.h"
+ #include "third_party/skia/include/core/SkRWBuffer.h"
++#include "third_party/skia/include/core/SkRefCnt.h"
+ #include "wtf/Noncopyable.h"
+ #include "wtf/PassRefPtr.h"
+ #include "wtf/ThreadSafeRefCounted.h"
+@@ -35,7 +36,7 @@ public:
+ 
+     // These versions use thread-safe input, so they are always thread-safe.
+     static PassRefPtr<SegmentReader> createFromSkData(sk_sp<SkData>);
+-    static PassRefPtr<SegmentReader> createFromSkROBuffer(PassRefPtr<SkROBuffer>);
++    static PassRefPtr<SegmentReader> createFromSkROBuffer(sk_sp<SkROBuffer>);
+ 
+     SegmentReader() {}
+     virtual ~SegmentReader() {}
+diff --git a/third_party/WebKit/Source/platform/image-decoders/gif/GIFImageDecoder.cpp b/third_party/WebKit/Source/platform/image-decoders/gif/GIFImageDecoder.cpp
+index a769b6d09bb28180c851a3f3e7128ba6077dbcf1..ba4cca2bb13c8da2bcc7cbc66cdad6fd869999b3 100644
+--- a/third_party/WebKit/Source/platform/image-decoders/gif/GIFImageDecoder.cpp
++++ b/third_party/WebKit/Source/platform/image-decoders/gif/GIFImageDecoder.cpp
+@@ -356,11 +356,14 @@ bool GIFImageDecoder::initFrameBuffer(size_t frameIndex)
+         if (!buffer->setSizeAndColorProfile(size().width(), size().height(), ImageFrame::ICCProfile()))
+             return setFailed();
+     } else {
+-        const ImageFrame* prevBuffer = &m_frameBufferCache[requiredPreviousFrameIndex];
++        ImageFrame* prevBuffer = &m_frameBufferCache[requiredPreviousFrameIndex];
+         ASSERT(prevBuffer->getStatus() == ImageFrame::FrameComplete);
+ 
+-        // Preserve the last frame as the starting state for this frame.
+-        if (!buffer->copyBitmapData(*prevBuffer))
++        // We try to reuse |prevBuffer| as starting state to avoid copying.
++        // For DisposeOverwritePrevious, the next frame will also use
++        // |prevBuffer| as its starting state, so we can't take over its image
++        // data using takeBitmapDataIfWritable.  Copy the data instead.
++        if ((buffer->getDisposalMethod() == ImageFrame::DisposeOverwritePrevious || !buffer->takeBitmapDataIfWritable(prevBuffer)) && !buffer->copyBitmapData(*prevBuffer))
+             return setFailed();
+ 
+         if (prevBuffer->getDisposalMethod() == ImageFrame::DisposeOverwriteBgcolor) {
+diff --git a/third_party/WebKit/Source/platform/image-decoders/webp/WEBPImageDecoder.cpp b/third_party/WebKit/Source/platform/image-decoders/webp/WEBPImageDecoder.cpp
+index 1e55c716838dfe0a1dfd4ad611bfa2dad053086c..38045ba73c1c17799c01e3044e5ea702cd666367 100644
+--- a/third_party/WebKit/Source/platform/image-decoders/webp/WEBPImageDecoder.cpp
++++ b/third_party/WebKit/Source/platform/image-decoders/webp/WEBPImageDecoder.cpp
+@@ -252,11 +252,14 @@ bool WEBPImageDecoder::initFrameBuffer(size_t frameIndex)
+             return setFailed();
+         m_frameBackgroundHasAlpha = !buffer.originalFrameRect().contains(IntRect(IntPoint(), size()));
+     } else {
+-        const ImageFrame& prevBuffer = m_frameBufferCache[requiredPreviousFrameIndex];
++        ImageFrame& prevBuffer = m_frameBufferCache[requiredPreviousFrameIndex];
+         ASSERT(prevBuffer.getStatus() == ImageFrame::FrameComplete);
+ 
+-        // Preserve the last frame as the starting state for this frame.
+-        if (!buffer.copyBitmapData(prevBuffer))
++        // Preserve the last frame as the starting state for this frame. We try
++        // to reuse |prevBuffer| as starting state to avoid copying.
++        // For BlendAtopPreviousFrame, both frames are required, so we can't
++        // take over its image data using takeBitmapDataIfWritable.
++        if ((buffer.getAlphaBlendSource() == ImageFrame::BlendAtopPreviousFrame || !buffer.takeBitmapDataIfWritable(&prevBuffer)) && !buffer.copyBitmapData(prevBuffer))
+             return setFailed();
+ 
+         if (prevBuffer.getDisposalMethod() == ImageFrame::DisposeOverwriteBgcolor) {
+diff --git a/third_party/WebKit/Source/platform/testing/TestPaintArtifact.cpp b/third_party/WebKit/Source/platform/testing/TestPaintArtifact.cpp
+index 6aff3b0142aa097b218fea974b7e54dfb1d46bdd..82be6c30ec1970ac67da22785b3ab4977fb24f96 100644
+--- a/third_party/WebKit/Source/platform/testing/TestPaintArtifact.cpp
++++ b/third_party/WebKit/Source/platform/testing/TestPaintArtifact.cpp
+@@ -25,20 +25,20 @@ public:
+     DummyRectClient(const FloatRect& rect, Color color) : m_rect(rect), m_color(color) {}
+     String debugName() const final { return "<dummy>"; }
+     LayoutRect visualRect() const final { return enclosingLayoutRect(m_rect); }
+-    PassRefPtr<SkPicture> makePicture() const;
++    sk_sp<SkPicture> makePicture() const;
+ private:
+     FloatRect m_rect;
+     Color m_color;
+ };
+ 
+-PassRefPtr<SkPicture> TestPaintArtifact::DummyRectClient::makePicture() const
++sk_sp<SkPicture> TestPaintArtifact::DummyRectClient::makePicture() const
+ {
+     SkPictureRecorder recorder;
+     SkCanvas* canvas = recorder.beginRecording(m_rect);
+     SkPaint paint;
+     paint.setColor(m_color.rgb());
+     canvas->drawRect(m_rect, paint);
+-    return fromSkSp(recorder.finishRecordingAsPicture());
++    return recorder.finishRecordingAsPicture();
+ }
+ 
+ TestPaintArtifact::TestPaintArtifact()
+diff --git a/third_party/WebKit/Source/platform/text/TextRun.h b/third_party/WebKit/Source/platform/text/TextRun.h
+index 9da5d7474495bebb5b4dc5f6d4ad438c09f857c5..4c30b34712f8bddc1ad6b1df9aac6505d277b31b 100644
+--- a/third_party/WebKit/Source/platform/text/TextRun.h
++++ b/third_party/WebKit/Source/platform/text/TextRun.h
+@@ -31,6 +31,7 @@
+ #include "platform/text/TabSize.h"
+ #include "platform/text/TextDirection.h"
+ #include "platform/text/TextPath.h"
++#include "third_party/skia/include/core/SkRefCnt.h"
+ #include "wtf/Allocator.h"
+ #include "wtf/text/StringView.h"
+ #include "wtf/text/WTFString.h"
+@@ -249,7 +250,7 @@ public:
+     unsigned from;
+     unsigned to;
+     FloatRect bounds;
+-    RefPtr<const SkTextBlob>* cachedTextBlob;
++    sk_sp<const SkTextBlob>* cachedTextBlob;
+ };
+ 
+ } // namespace blink
+diff --git a/third_party/WebKit/Source/platform/transforms/SkewTransformOperation.h b/third_party/WebKit/Source/platform/transforms/SkewTransformOperation.h
+index de3b683e52be063cc1c3134b48e4643288b1d02b..f359cd1476a5f5ab50691e0a4ae30e2857f0c00c 100644
+--- a/third_party/WebKit/Source/platform/transforms/SkewTransformOperation.h
++++ b/third_party/WebKit/Source/platform/transforms/SkewTransformOperation.h
+@@ -26,6 +26,7 @@
+ #define SkewTransformOperation_h
+ 
+ #include "platform/transforms/TransformOperation.h"
++#include "wtf/PassRefPtr.h"
+ 
+ namespace blink {
+ 
 diff --git a/third_party/WebKit/Source/web/WebArrayBuffer.cpp b/third_party/WebKit/Source/web/WebArrayBuffer.cpp
 index 471ce6a5c66f6a7240732a12596746ef239a48e1..29b0bbdff9dfe9d0e1d1fb943b36bb98a7bea385 100644
 --- a/third_party/WebKit/Source/web/WebArrayBuffer.cpp
@@ -2381,6 +7950,224 @@ index 471ce6a5c66f6a7240732a12596746ef239a48e1..29b0bbdff9dfe9d0e1d1fb943b36bb98
  void WebArrayBuffer::reset()
  {
      m_private.reset();
+diff --git a/third_party/WebKit/Source/web/WebSerializedScriptValue.cpp b/third_party/WebKit/Source/web/WebSerializedScriptValue.cpp
+index 4603ef0c4e18cd44ff90c80f52473deaae4fc779..09dbf996b365069055d50ed5efcbb063ffb69920 100644
+--- a/third_party/WebKit/Source/web/WebSerializedScriptValue.cpp
++++ b/third_party/WebKit/Source/web/WebSerializedScriptValue.cpp
+@@ -76,12 +76,12 @@ v8::Local<v8::Value> WebSerializedScriptValue::deserialize()
+     return m_private->deserialize();
+ }
+ 
+-WebSerializedScriptValue::WebSerializedScriptValue(const PassRefPtr<SerializedScriptValue>& value)
++WebSerializedScriptValue::WebSerializedScriptValue(PassRefPtr<SerializedScriptValue> value)
+     : m_private(value)
+ {
+ }
+ 
+-WebSerializedScriptValue& WebSerializedScriptValue::operator=(const PassRefPtr<SerializedScriptValue>& value)
++WebSerializedScriptValue& WebSerializedScriptValue::operator=(PassRefPtr<SerializedScriptValue> value)
+ {
+     m_private = value;
+     return *this;
+diff --git a/third_party/WebKit/Source/web/linux/WebFontRendering.cpp b/third_party/WebKit/Source/web/linux/WebFontRendering.cpp
+index 2132f01a56b915fd920383acf4b3e1c898ac9132..79f440c3d46da0ff7432ef34a064603cb24d9d80 100644
+--- a/third_party/WebKit/Source/web/linux/WebFontRendering.cpp
++++ b/third_party/WebKit/Source/web/linux/WebFontRendering.cpp
+@@ -44,7 +44,7 @@ namespace blink {
+ void WebFontRendering::setSkiaFontManager(SkFontMgr* fontMgr)
+ {
+     WTF::adopted(fontMgr);
+-    FontCache::setFontManager(RefPtr<SkFontMgr>(fontMgr));
++    FontCache::setFontManager(sk_ref_sp(fontMgr));
+ }
+ 
+ // static
+diff --git a/third_party/WebKit/Source/web/win/WebFontRendering.cpp b/third_party/WebKit/Source/web/win/WebFontRendering.cpp
+index 6611727e3007af99ed1e26e9e4ba45539d94f866..1721ca15dc91527c4a8d36d36b1afc13e23d3600 100644
+--- a/third_party/WebKit/Source/web/win/WebFontRendering.cpp
++++ b/third_party/WebKit/Source/web/win/WebFontRendering.cpp
+@@ -12,7 +12,7 @@ namespace blink {
+ void WebFontRendering::setSkiaFontManager(SkFontMgr* fontMgr)
+ {
+     WTF::adopted(fontMgr);
+-    FontCache::setFontManager(RefPtr<SkFontMgr>(fontMgr));
++    FontCache::setFontManager(sk_ref_sp(fontMgr));
+ }
+ 
+ // static
+diff --git a/third_party/WebKit/public/platform/WebCrypto.h b/third_party/WebKit/public/platform/WebCrypto.h
+index ba3d98fa80b84d97ef133c85792cba2943508fe8..27cba7ef3d1bbd929a426f8211329282fc606b9f 100644
+--- a/third_party/WebKit/public/platform/WebCrypto.h
++++ b/third_party/WebKit/public/platform/WebCrypto.h
+@@ -42,6 +42,7 @@
+ 
+ #if INSIDE_BLINK
+ #include "platform/heap/Handle.h"
++#include "wtf/PassRefPtr.h"
+ #endif
+ 
+ namespace blink {
+@@ -97,7 +98,7 @@ public:
+     BLINK_PLATFORM_EXPORT bool cancelled() const;
+ 
+ #if INSIDE_BLINK
+-    BLINK_PLATFORM_EXPORT WebCryptoResult(CryptoResult*, const PassRefPtr<CryptoResultCancel>&);
++    BLINK_PLATFORM_EXPORT WebCryptoResult(CryptoResult*, PassRefPtr<CryptoResultCancel>);
+ #endif
+ 
+ private:
+diff --git a/third_party/WebKit/public/platform/WebData.h b/third_party/WebKit/public/platform/WebData.h
+index e4d6b879c237732e7eb10c81d617fa4d76d2dda1..bc3ae37783bc1f64f5c969590de633717d0afbb5 100644
+--- a/third_party/WebKit/public/platform/WebData.h
++++ b/third_party/WebKit/public/platform/WebData.h
+@@ -34,6 +34,10 @@
+ #include "WebCommon.h"
+ #include "WebPrivatePtr.h"
+ 
++#if INSIDE_BLINK
++#include "wtf/PassRefPtr.h"
++#endif
++
+ namespace blink {
+ 
+ class SharedBuffer;
+@@ -78,8 +82,8 @@ public:
+     bool isNull() const { return m_private.isNull(); }
+ 
+ #if INSIDE_BLINK
+-    WebData(const PassRefPtr<SharedBuffer>&);
+-    WebData& operator=(const PassRefPtr<SharedBuffer>&);
++    WebData(PassRefPtr<SharedBuffer>);
++    WebData& operator=(PassRefPtr<SharedBuffer>);
+     operator PassRefPtr<SharedBuffer>() const;
+ #else
+     template <class C>
+diff --git a/third_party/WebKit/public/platform/WebHTTPBody.h b/third_party/WebKit/public/platform/WebHTTPBody.h
+index e604707a0a9816a57577a6cf2c9a3b4c1d407749..22d6cacc8601cfc8fa7588b97d255a6a4f6e3f15 100644
+--- a/third_party/WebKit/public/platform/WebHTTPBody.h
++++ b/third_party/WebKit/public/platform/WebHTTPBody.h
+@@ -38,7 +38,7 @@
+ #include "WebURL.h"
+ 
+ #if INSIDE_BLINK
+-namespace WTF { template <typename T> class PassRefPtr; }
++#include "wtf/PassRefPtr.h"
+ #endif
+ 
+ namespace blink {
+@@ -101,8 +101,8 @@ public:
+     BLINK_PLATFORM_EXPORT void setContainsPasswordData(bool);
+ 
+ #if INSIDE_BLINK
+-    BLINK_PLATFORM_EXPORT WebHTTPBody(const WTF::PassRefPtr<EncodedFormData>&);
+-    BLINK_PLATFORM_EXPORT WebHTTPBody& operator=(const WTF::PassRefPtr<EncodedFormData>&);
++    BLINK_PLATFORM_EXPORT WebHTTPBody(WTF::PassRefPtr<EncodedFormData>);
++    BLINK_PLATFORM_EXPORT WebHTTPBody& operator=(WTF::PassRefPtr<EncodedFormData>);
+     BLINK_PLATFORM_EXPORT operator WTF::PassRefPtr<EncodedFormData>() const;
+ #endif
+ 
+diff --git a/third_party/WebKit/public/platform/WebImage.h b/third_party/WebKit/public/platform/WebImage.h
+index 15716beafb043a8ec3fdc447197c8fbb7f48b940..4fd01893171eeb2ba199a4f63859dc5fa854c909 100644
+--- a/third_party/WebKit/public/platform/WebImage.h
++++ b/third_party/WebKit/public/platform/WebImage.h
+@@ -37,7 +37,7 @@
+ #include "third_party/skia/include/core/SkBitmap.h"
+ 
+ #if INSIDE_BLINK
+-namespace WTF { template <typename T> class PassRefPtr; }
++#include "wtf/PassRefPtr.h"
+ #endif
+ 
+ namespace blink {
+@@ -80,7 +80,7 @@ public:
+     BLINK_PLATFORM_EXPORT WebSize size() const;
+ 
+ #if INSIDE_BLINK
+-    BLINK_PLATFORM_EXPORT WebImage(const WTF::PassRefPtr<Image>&);
++    BLINK_PLATFORM_EXPORT WebImage(WTF::PassRefPtr<Image>);
+ #endif
+ 
+     WebImage(const SkBitmap& bitmap) : m_bitmap(bitmap) { }
+diff --git a/third_party/WebKit/public/platform/WebPrivatePtr.h b/third_party/WebKit/public/platform/WebPrivatePtr.h
+index 0b6533d4a0129b9f13f1198a16618690a79a47e8..e46b01c37fdfe734868193f9b2db22f5c2016a29 100644
+--- a/third_party/WebKit/public/platform/WebPrivatePtr.h
++++ b/third_party/WebKit/public/platform/WebPrivatePtr.h
+@@ -217,7 +217,7 @@ private:
+ //        // Methods that are used only by other Blink classes should only be
+ //        // declared when INSIDE_BLINK is set.
+ //    #if INSIDE_BLINK
+-//        WebFoo(const WTF::PassRefPtr<Foo>&);
++//        WebFoo(WTF::PassRefPtr<Foo>);
+ //    #endif
+ //
+ //    private:
+diff --git a/third_party/WebKit/public/platform/WebSecurityOrigin.h b/third_party/WebKit/public/platform/WebSecurityOrigin.h
+index 528e473bbb6fbd0e4277a43ae20fbc4147229646..1c1a05e093469a133b6e949bf36fe37b71c8a167 100644
+--- a/third_party/WebKit/public/platform/WebSecurityOrigin.h
++++ b/third_party/WebKit/public/platform/WebSecurityOrigin.h
+@@ -109,8 +109,8 @@ public:
+     BLINK_PLATFORM_EXPORT void grantLoadLocalResources() const;
+ 
+ #if INSIDE_BLINK
+-    BLINK_PLATFORM_EXPORT WebSecurityOrigin(const WTF::PassRefPtr<SecurityOrigin>&);
+-    BLINK_PLATFORM_EXPORT WebSecurityOrigin& operator=(const WTF::PassRefPtr<SecurityOrigin>&);
++    BLINK_PLATFORM_EXPORT WebSecurityOrigin(WTF::PassRefPtr<SecurityOrigin>);
++    BLINK_PLATFORM_EXPORT WebSecurityOrigin& operator=(WTF::PassRefPtr<SecurityOrigin>);
+     BLINK_PLATFORM_EXPORT operator WTF::PassRefPtr<SecurityOrigin>() const;
+     BLINK_PLATFORM_EXPORT SecurityOrigin* get() const;
+ #else
+diff --git a/third_party/WebKit/public/platform/WebThreadSafeData.h b/third_party/WebKit/public/platform/WebThreadSafeData.h
+index d741f3f46135498f8455cfe84cfde68903c5a904..8724c77b4ff142bb1f8ecbac81aaf2e00bf693a5 100644
+--- a/third_party/WebKit/public/platform/WebThreadSafeData.h
++++ b/third_party/WebKit/public/platform/WebThreadSafeData.h
+@@ -34,7 +34,9 @@
+ #include "WebCommon.h"
+ #include "WebPrivatePtr.h"
+ 
+-#if !INSIDE_BLINK
++#if INSIDE_BLINK
++#include "wtf/PassRefPtr.h"
++#else
+ #include <string>
+ #endif
+ 
+@@ -63,8 +65,8 @@ public:
+     BLINK_PLATFORM_EXPORT WebThreadSafeData& operator=(const WebThreadSafeData&);
+ 
+ #if INSIDE_BLINK
+-    BLINK_PLATFORM_EXPORT WebThreadSafeData(const WTF::PassRefPtr<RawData>&);
+-    BLINK_PLATFORM_EXPORT WebThreadSafeData& operator=(const WTF::PassRefPtr<RawData>&);
++    BLINK_PLATFORM_EXPORT WebThreadSafeData(WTF::PassRefPtr<RawData>);
++    BLINK_PLATFORM_EXPORT WebThreadSafeData& operator=(WTF::PassRefPtr<RawData>);
+ #else
+     operator std::string() const
+     {
+diff --git a/third_party/WebKit/public/platform/WebURLLoadTiming.h b/third_party/WebKit/public/platform/WebURLLoadTiming.h
+index fc48965f7e31d6876237be23ecf55d9a0cb402fa..920744e909c501863eab5e2e1f05fc4faf58bb5c 100644
+--- a/third_party/WebKit/public/platform/WebURLLoadTiming.h
++++ b/third_party/WebKit/public/platform/WebURLLoadTiming.h
+@@ -34,6 +34,10 @@
+ #include "WebCommon.h"
+ #include "WebPrivatePtr.h"
+ 
++#if INSIDE_BLINK
++#include "wtf/PassRefPtr.h"
++#endif
++
+ namespace blink {
+ 
+ class ResourceLoadTiming;
+@@ -105,8 +109,8 @@ public:
+     BLINK_PLATFORM_EXPORT void setPushEnd(double);
+ 
+ #if INSIDE_BLINK
+-    BLINK_PLATFORM_EXPORT WebURLLoadTiming(const WTF::PassRefPtr<ResourceLoadTiming>&);
+-    BLINK_PLATFORM_EXPORT WebURLLoadTiming& operator=(const WTF::PassRefPtr<ResourceLoadTiming>&);
++    BLINK_PLATFORM_EXPORT WebURLLoadTiming(WTF::PassRefPtr<ResourceLoadTiming>);
++    BLINK_PLATFORM_EXPORT WebURLLoadTiming& operator=(WTF::PassRefPtr<ResourceLoadTiming>);
+     BLINK_PLATFORM_EXPORT operator WTF::PassRefPtr<ResourceLoadTiming>() const;
+ #endif
+ 
 diff --git a/third_party/WebKit/public/web/WebArrayBuffer.h b/third_party/WebKit/public/web/WebArrayBuffer.h
 index 668bbfdbe72ebe2607e67785d267d03a6434dda5..85a6c28349001aebd7538eae21213668022acd24 100644
 --- a/third_party/WebKit/public/web/WebArrayBuffer.h
@@ -2393,6 +8180,32 @@ index 668bbfdbe72ebe2607e67785d267d03a6434dda5..85a6c28349001aebd7538eae21213668
  
      BLINK_EXPORT void reset();
      BLINK_EXPORT void assign(const WebArrayBuffer&);
+diff --git a/third_party/WebKit/public/web/WebSerializedScriptValue.h b/third_party/WebKit/public/web/WebSerializedScriptValue.h
+index a5719d66e4b8376ce3ec884cd8aad070f9e8dee9..3fbca98cc06619d3205ba5e358e6a25763440092 100644
+--- a/third_party/WebKit/public/web/WebSerializedScriptValue.h
++++ b/third_party/WebKit/public/web/WebSerializedScriptValue.h
+@@ -31,8 +31,8 @@
+ #ifndef WebSerializedScriptValue_h
+ #define WebSerializedScriptValue_h
+ 
+-#include "../platform/WebCommon.h"
+-#include "../platform/WebPrivatePtr.h"
++#include "public/platform/WebCommon.h"
++#include "public/platform/WebPrivatePtr.h"
+ 
+ namespace v8 {
+ class Value;
+@@ -76,8 +76,8 @@ public:
+     BLINK_EXPORT v8::Local<v8::Value> deserialize();
+ 
+ #if BLINK_IMPLEMENTATION
+-    WebSerializedScriptValue(const WTF::PassRefPtr<SerializedScriptValue>&);
+-    WebSerializedScriptValue& operator=(const WTF::PassRefPtr<SerializedScriptValue>&);
++    WebSerializedScriptValue(WTF::PassRefPtr<SerializedScriptValue>);
++    WebSerializedScriptValue& operator=(WTF::PassRefPtr<SerializedScriptValue>);
+     operator WTF::PassRefPtr<SerializedScriptValue>() const;
+ #endif
+ 
 diff --git a/third_party/widevine/cdm/BUILD.gn b/third_party/widevine/cdm/BUILD.gn
 index e5fdb29e858fec1137a2182c18db6304279b4c24..8a860a334c2204a890ba73de9eacc2ba8ae8bb91 100644
 --- a/third_party/widevine/cdm/BUILD.gn


### PR DESCRIPTION
https://chromium.googlesource.com/chromium/src.git/+/3a38c33c398189620281ad19a0f8e5b7f6ac3e69

must pick these commits in order first and do some proper modification
1. https://chromium.googlesource.com/chromium/src/+/605fa62ea2c9ac2924ff08f21106775d412bed5b
2. https://chromium.googlesource.com/chromium/src/+/3fd7c79eea0cb0f981a73b1264568366214f229e
3. https://chromium.googlesource.com/chromium/src/+/78115b26dfafd0fca676ac33caabd3aa8b43ecf4
4. https://chromium.googlesource.com/chromium/src/+/69969af74bfff920f5fdcc2aa547ea4af2d477d2

should be removed when upgrading to chromium 55

fix https://github.com/brave/browser-laptop/issues/6656

Auditors: @bbondy, @bridiver, @bsclifton