### PR TITLE
Make component extensions disable-able

### DIFF
--- a/atom/browser/extensions/atom_extension_system.cc
+++ b/atom/browser/extensions/atom_extension_system.cc
@@ -258,6 +258,7 @@ void AtomExtensionSystem::Shared::DisableExtension(
       !(disable_reasons & Extension::DISABLE_RELOAD) &&
       !(disable_reasons & Extension::DISABLE_UPDATE_REQUIRED_BY_POLICY) &&
       extension->location() != Manifest::EXTERNAL_COMPONENT &&
+      extension->location() != Manifest::COMPONENT &&
       extension->location() != Manifest::UNPACKED) {
     return;
   }

--- a/atom/browser/extensions/tab_helper.cc
+++ b/atom/browser/extensions/tab_helper.cc
@@ -308,7 +308,8 @@ base::DictionaryValue* TabHelper::CreateTabValue(
                      contents->GetBrowserContext()->IsOffTheRecord());
   result->SetBoolean(keys::kActiveKey, active);
   result->SetString(keys::kUrlKey, contents->GetURL().spec());
-  result->SetString(keys::kTitleKey, entry ? base::UTF16ToUTF8(entry->GetTitle()) : "");
+  result->SetString(keys::kTitleKey, entry
+      ? base::UTF16ToUTF8(entry->GetTitle()) : "");
   result->SetString(keys::kStatusKey, contents->IsLoading()
       ? "loading" : "complete");
   result->SetBoolean(keys::kAudibleKey, contents->WasRecentlyAudible());


### PR DESCRIPTION
This is needed to reload the Brave extension to address brave/sync#43 (restart sync background script without restarting the browser)