### PR TITLE
Fix yellow border issue when rendering select control on Windows

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -357,6 +357,18 @@ source_set("native_mate") {
 
 electron_framework_sources = []
 
+if (is_win) {
+  electron_framework_sources += [
+    "$root_out_dir/chrome_100_percent.pak",
+  ]
+
+  if (enable_hidpi) {
+    electron_framework_sources += [
+      "$root_out_dir/chrome_200_percent.pak",
+    ]
+  }
+}
+
 electron_framework_public_deps = [
   ":packed_resources",
 ]


### PR DESCRIPTION
The absence of both .pak files in the final package (prebuilt) was causing the borders of the select box to be bright yellow (#FFFF00)

These were removed with https://github.com/brave/muon/commit/29ab58342ec11a37d55f2f2ad7e32c89238b7976 (not sure if this was intentional)

Fixes https://github.com/brave/browser-laptop/issues/7184

Auditors: @darkdh, @bbondy