### PR TITLE
Re-add missing pak files (linux). 

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -357,7 +357,7 @@ source_set("native_mate") {
 
 electron_framework_sources = []
 
-if (is_win) {
+if (!is_mac) {
   electron_framework_sources += [
     "$root_out_dir/chrome_100_percent.pak",
   ]


### PR DESCRIPTION
These were unintentionally removed with https://github.com/brave/muon/commit/29ab58342ec11a37d55f2f2ad7e32c89238b7976 and were added back on Windows with https://github.com/brave/muon/commit/662bc7a444006eca8bb8e43eeb07f6c8d5d66f45

Fixes https://github.com/brave/browser-laptop/issues/7260