### PR TITLE
Fix printToPDF on chromium56

### DIFF
--- a/lib/browser/api/web-contents.js
+++ b/lib/browser/api/web-contents.js
@@ -79,7 +79,8 @@ const defaultPrintingSetting = {
   copies: 1,
   collate: true,
   shouldPrintBackgrounds: false,
-  shouldPrintSelectionOnly: false
+  shouldPrintSelectionOnly: false,
+  scaleFactor: 100
 }
 
 // JavaScript implementations of WebContents.


### PR DESCRIPTION
fix https://github.com/brave/browser-laptop/issues/7416

Auditors: @bridiver, @bbondy, @bsclifton

1. Use RenderFrameHost instead of RenderViewHost
(https://chromium.googlesource.com/chromium/src.git/+/cb959ce66a9a89b6f100795bb33292439a7ed7de)
2. Add scaleFactor for check in https://chromium.googlesource.com/chromium/src.git/+/56.0.2924.87/printing/print_settings_conversion.cc#187
(https://chromium.googlesource.com/chromium/src.git/+/769ffdf779d83399a6f219e2637c6469ab94da0e
3. Add correct HostID & RountingID for CreatePrinterQuery
(https://chromium.googlesource.com/chromium/src.git/+/56.0.2924.87/chrome/browser/printing/printing_message_filter.cc#267)