### PR TITLE
Hide autofill popup only when webcontent is focused

### DIFF
--- a/atom/browser/autofill/atom_autofill_client.cc
+++ b/atom/browser/autofill/atom_autofill_client.cc
@@ -196,7 +196,7 @@ void AtomAutofillClient::UpdateAutofillPopupDataListValues(
 }
 
 void AtomAutofillClient::HideAutofillPopup() {
-  if (api_web_contents_) {
+  if (api_web_contents_ && api_web_contents_->IsFocused()) {
     api_web_contents_->Emit("hide-autofill-popup");
   }
 }


### PR DESCRIPTION
There will be a follow-up cleanup in browser-laptop and I will mark
issue fixed there.

Address https://github.com/brave/muon/commit/fcaecc2f6230e700b858153c768fbe725027d1d7

Auditors: @bridiver, @bbondy, @bsclifton