### PR TITLE
Use the correct JavaScript environment search path dir

### DIFF
--- a/atom/browser/javascript_environment.cc
+++ b/atom/browser/javascript_environment.cc
@@ -63,12 +63,17 @@ std::vector<base::FilePath> GetModuleSearchPaths() {
 
   auto command_line = base::CommandLine::ForCurrentProcess();
   base::FilePath source_root = command_line->GetSwitchValuePath("source-root");
-  if (source_root.empty() &&
-      !base::PathService::Get(base::DIR_SOURCE_ROOT, &source_root)) {
+  if (source_root.empty()) {
     source_root = GetResourcesDir().Append(FILE_PATH_LITERAL("app.asar"));
   }
 
-  if (base::PathExists(source_root)) {
+  bool path_exists = base::PathExists(source_root);
+  if (!path_exists) {
+    base::PathService::Get(base::DIR_SOURCE_ROOT, &source_root);
+    path_exists = base::PathExists(source_root);
+  }
+
+  if (path_exists) {
     search_paths.push_back(source_root);
     search_paths.push_back(source_root.Append(FILE_PATH_LITERAL("app")));
     search_paths.push_back(source_root


### PR DESCRIPTION
The directory was not being set correctly for packaged builds.  In particular base::DIR_SOURCE_ROOT was returning a directory that wasn't correct.   In dev builds it would return /Users/bbondy/projects/brave/browser-laptop-bootstrap/src/browser-laptop and in packaged builds that were run from /Users/bbondy/projects/brave/browser-laptop-bootstrap/src/browser-laptop/Brave-darwin-x64/Brave.app it would return /Users/bbondy/projects/brave/browser-laptop-bootstrap/src/.

To fix this I just use the resource path's app.asar file if it exists first and only fallback to the search path if that doesn't exist since it only exists in packaged builds.

Fix https://github.com/brave/browser-laptop/issues/8195

Auditors: @bridiver