### PR TITLE
Disble Isolate Extensions by default

### DIFF
--- a/chromium_src/chrome/browser/browser_process_impl.cc
+++ b/chromium_src/chrome/browser/browser_process_impl.cc
@@ -227,18 +227,9 @@ void BrowserProcessImpl::ResourceDispatcherHostCreated() {
 
 void BrowserProcessImpl::PreCreateThreads() {
 #if BUILDFLAG(ENABLE_EXTENSIONS)
-  // Register the chrome-extension scheme to reflect the extension process
-  // model. Controlled by a field trial, so we can't do this earlier.
-  base::FieldTrialList::FindFullName("SiteIsolationExtensions");
-  if (extensions::IsIsolateExtensionsEnabled()) {
-    // chrome-extension:// URLs are safe to request anywhere, but may only
-    // commit (including in iframes) in extension processes.
-    ChildProcessSecurityPolicy::GetInstance()->RegisterWebSafeIsolatedScheme(
-        extensions::kExtensionScheme, true);
-  } else {
-    ChildProcessSecurityPolicy::GetInstance()->RegisterWebSafeScheme(
-        extensions::kExtensionScheme);
-  }
+  // Disable Isolate Extensions by default
+  ChildProcessSecurityPolicy::GetInstance()->RegisterWebSafeScheme(
+      extensions::kExtensionScheme);
 #endif
 }
 


### PR DESCRIPTION
This get turned on by default in
https://chromium.googlesource.com/chromium/src/+/9e1897b5c7dab9c190fc3c919a1c4662af63b3e6

fix https://github.com/brave/browser-laptop/issues/8422

Auditors: @bridiver, @bbondy