### PR TITLE
Menu is now properly hidden when toggled (only used in Brave for Linux).

### DIFF
--- a/atom/browser/native_window_views.cc
+++ b/atom/browser/native_window_views.cc
@@ -1277,7 +1277,8 @@ void NativeWindowViews::HandleKeyboardEvent(
 void NativeWindowViews::Layout() {
   const auto size = GetContentsBounds().size();
   const auto menu_bar_bounds =
-      menu_bar_ ? gfx::Rect(0, 0, size.width(), kMenuBarHeight) : gfx::Rect();
+      menu_bar_visible_ ? gfx::Rect(0, 0, size.width(), kMenuBarHeight)
+                        : gfx::Rect();
   if (menu_bar_) {
     menu_bar_->SetBoundsRect(menu_bar_bounds);
   }


### PR DESCRIPTION
Initial PR was done with https://github.com/brave/muon/pull/191 but I missed https://github.com/electron/electron/commit/dcf6c52f51bcf3635bd97238a851f73cda1d7b40

Fixes https://github.com/brave/browser-laptop/issues/8839

Auditors: @bbondy, @bridiver