### PR TITLE
Using pending credential instead of submitted form which might contain empty username

### DIFF
--- a/brave/browser/password_manager/brave_password_manager_client.cc
+++ b/brave/browser/password_manager/brave_password_manager_client.cc
@@ -137,8 +137,7 @@ void BravePasswordManagerClient::DidClickNever() {
 
 void BravePasswordManagerClient::DidClickUpdate() {
   if (form_to_save_) {
-    const autofill::PasswordForm *form = form_to_save_->submitted_form();
-    form_to_save_->Update(*form);
+    form_to_save_->Update(form_to_save_->pending_credentials());
   }
 }
 


### PR DESCRIPTION
fix https://github.com/brave/browser-laptop/issues/9028

Auditors: @bridiver, @bbondy