### PR TITLE
Address change of removing nested message loop

### DIFF
--- a/atom/browser/api/atom_api_menu_views.cc
+++ b/atom/browser/api/atom_api_menu_views.cc
@@ -8,14 +8,16 @@
 #include "atom/browser/unresponsive_suppressor.h"
 #include "content/public/browser/render_widget_host_view.h"
 #include "ui/display/screen.h"
-#include "ui/views/controls/menu/menu_runner.h"
+
+using views::MenuRunner;
 
 namespace atom {
 
 namespace api {
 
 MenuViews::MenuViews(v8::Isolate* isolate, v8::Local<v8::Object> wrapper)
-    : Menu(isolate, wrapper) {
+    : Menu(isolate, wrapper),
+      weak_factory_(this) {
 }
 
 void MenuViews::PopupAt(Window* window, int x, int y, int positioning_item) {
@@ -42,15 +44,21 @@ void MenuViews::PopupAt(Window* window, int x, int y, int positioning_item) {
   atom::UnresponsiveSuppressor suppressor;
 
   // Show the menu.
-  views::MenuRunner menu_runner(
+  menu_runner_.reset(new MenuRunner(
       model(),
-      views::MenuRunner::CONTEXT_MENU | views::MenuRunner::HAS_MNEMONICS);
-  ignore_result(menu_runner.RunMenuAt(
+      MenuRunner::CONTEXT_MENU | MenuRunner::HAS_MNEMONICS,
+      base::Bind(&MenuViews::OnMenuClosed, weak_factory_.GetWeakPtr())));
+  ignore_result(menu_runner_->RunMenuAt(
       static_cast<NativeWindowViews*>(window->window())->widget(),
       NULL,
       gfx::Rect(location, gfx::Size()),
       views::MENU_ANCHOR_TOPLEFT,
       ui::MENU_SOURCE_MOUSE));
+}
+
+void MenuViews::OnMenuClosed() {
+  menu_runner_.reset();
+  Destroy();
 }
 
 // static

--- a/atom/browser/api/atom_api_menu_views.h
+++ b/atom/browser/api/atom_api_menu_views.h
@@ -6,7 +6,9 @@
 #define ATOM_BROWSER_API_ATOM_API_MENU_VIEWS_H_
 
 #include "atom/browser/api/atom_api_menu.h"
+#include "base/memory/weak_ptr.h"
 #include "ui/display/screen.h"
+#include "ui/views/controls/menu/menu_runner.h"
 
 namespace atom {
 
@@ -18,8 +20,12 @@ class MenuViews : public Menu {
 
  protected:
   void PopupAt(Window* window, int x, int y, int positioning_item) override;
+  void OnMenuClosed();
 
  private:
+  std::unique_ptr<views::MenuRunner> menu_runner_;
+  base::WeakPtrFactory<MenuViews> weak_factory_;
+
   DISALLOW_COPY_AND_ASSIGN(MenuViews);
 };
 

--- a/atom/browser/api/trackable_object.h
+++ b/atom/browser/api/trackable_object.h
@@ -16,6 +16,12 @@ namespace base {
 class SupportsUserData;
 }
 
+namespace atom {
+namespace api {
+  class MenuViews;
+}
+}
+
 namespace mate {
 
 // Users should use TrackableObject instead.
@@ -45,6 +51,8 @@ class TrackableObjectBase {
   int32_t weak_map_id_;
 
  private:
+  friend class atom::api::MenuViews;
+
   void Destroy();
 
   base::Closure cleanup_;


### PR DESCRIPTION
```
All menus on aura platforms no longer use the nested message loop
code path of MenuController.

On Mac non-native menus also no longer use the nested message
loop. While native menus are handled vis menu_runner_impl_cocoa,
which does block.

This change removes the Nested Message Loop code paths from
MenuController.

Additionally some tests which specifically were for
nested message loops below asynchronous menus, have been
either transitioned, or removed if redundant.
```
https://chromium.googlesource.com/chromium/src.git/+/b31c887a2d14761b078f329629f1d3469106b891%5E%21/

It also forced menu to be async so we must make sure menu runner is alive until
menu closed.

requires https://github.com/brave/browser-laptop/pull/9128

fix https://github.com/brave/browser-laptop/issues/9100

Auditors: @bsclifton, @bridiver, @bbondy