### PR TITLE
Make muon.url.parse work more like Node's

### DIFF
--- a/brave/common/extensions/url_bindings.cc
+++ b/brave/common/extensions/url_bindings.cc
@@ -334,14 +334,14 @@ void URLBindings::Parse(
     if (gurl.has_username())
       dict.Set("auth", gurl.username() + (gurl.has_password()
         ? ":" + gurl.password() : ""));
-    dict.Set("hash", gurl.ref());
+    dict.Set("hash", (gurl.has_ref() ? "#" : "") + gurl.ref());
     dict.Set("hostname", gurl.host());
-    dict.Set("host", gurl.host() + ":" + gurl.port());
+    dict.Set("host", gurl.host() + (gurl.has_port() ? ":" + gurl.port() : ""));
     dict.Set("href", gurl.possibly_invalid_spec());
     dict.Set("path", gurl.PathForRequest());
     dict.Set("pathname", gurl.path());
     dict.Set("port", gurl.port());
-    dict.Set("protocol", gurl.scheme());
+    dict.Set("protocol", gurl.scheme() + (gurl.has_scheme() ? ":" : ""));
     dict.Set("query", gurl.query());
     dict.Set("search", "?" + gurl.query());
     dict.Set("origin", gurl.GetOrigin());


### PR DESCRIPTION
Fix https://github.com/brave/browser-laptop/issues/9503

the only other difference that i can tell is that muon.url.parse does not have the `slashes` field. however its only use in browser-laptop can be replaced by the `origin` field.