### PR TITLE
Make task_tracker an instance var on atom_api_session

### DIFF
--- a/atom/browser/api/atom_api_session.cc
+++ b/atom/browser/api/atom_api_session.cc
@@ -426,12 +426,11 @@ void Session::ClearHistory(mate::Arguments* args) {
           Profile::FromBrowserContext(browser_context()),
           ServiceAccessType::EXPLICIT_ACCESS);
 
-  base::CancelableTaskTracker task_tracker;
   history_service->ExpireHistoryBetween(std::set<GURL>(),
                                         base::Time(),
                                         base::Time::Max(),
                                         callback,
-                                        &task_tracker);
+                                        &task_tracker_);
 }
 
 void Session::FlushStorageData() {

--- a/atom/browser/api/atom_api_session.h
+++ b/atom/browser/api/atom_api_session.h
@@ -8,6 +8,7 @@
 #include <string>
 
 #include "atom/browser/api/trackable_object.h"
+#include "base/task/cancelable_task_tracker.h"
 #include "base/values.h"
 #include "content/public/browser/download_manager.h"
 #include "native_mate/handle.h"
@@ -106,6 +107,9 @@ class Session: public mate::TrackableObject<Session>,
 
   // The X-DevTools-Emulate-Network-Conditions-Client-Id.
   std::string devtools_network_emulation_client_id_;
+
+  // The task tracker for the HistoryService callbacks.
+  base::CancelableTaskTracker task_tracker_;
 
   AtomBrowserContext* browser_context_;
 


### PR DESCRIPTION
Fix brave/browser-laptop#9351