### PR TITLE
Fix broken menus on Linux / Gnome (introduced w/ C59)

### DIFF
--- a/atom/browser/ui/views/menu_bar.cc
+++ b/atom/browser/ui/views/menu_bar.cc
@@ -53,9 +53,11 @@ MenuBar::MenuBar()
   UpdateMenuBarColor();
   SetLayoutManager(new views::BoxLayout(
       views::BoxLayout::kHorizontal, 0, 0, 0));
+  menu_delegate_ = new MenuDelegate(this);
 }
 
 MenuBar::~MenuBar() {
+  if (menu_delegate_) delete menu_delegate_;
 }
 
 void MenuBar::SetMenu(AtomMenuModel* model) {
@@ -151,8 +153,7 @@ void MenuBar::OnMenuButtonClicked(views::MenuButton* source,
     return;
   }
 
-  MenuDelegate menu_delegate(this);
-  menu_delegate.RunMenu(menu_model_->GetSubmenuModelAt(id), source);
+  menu_delegate_->RunMenu(menu_model_->GetSubmenuModelAt(id), source);
 }
 
 void MenuBar::OnNativeThemeChanged(const ui::NativeTheme* theme) {

--- a/atom/browser/ui/views/menu_bar.h
+++ b/atom/browser/ui/views/menu_bar.h
@@ -63,6 +63,7 @@ class MenuBar : public views::View,
   void UpdateMenuBarColor();
 
   SkColor background_color_;
+  MenuDelegate* menu_delegate_;
 
 #if defined(USE_X11)
   SkColor enabled_color_;


### PR DESCRIPTION
Keep reference to MenuDelegate as a member (so it won't go out of scope and auto-close/destroy).

Fixes https://github.com/brave/browser-laptop/issues/9470

Auditor: @darkdh 