### PR TITLE
Import password from Chrome/Canary/Chromium

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -244,12 +244,19 @@ source_set("utility") {
     "//content/public/common",
   ]
 
+  defines = [ ]
+
   deps = [
     "chromium_src:importer",
     "//chrome/common",
     "//chrome/utility",
     "//third_party/protobuf:protobuf_lite",
   ]
+
+  if (use_glib) {
+    defines += [ "USE_LIBSECRET" ]
+    deps += [ "//third_party/libsecret" ]
+  }
 
   sources = [
     "atom/utility/atom_content_utility_client.cc",

--- a/atom/common/importer/chrome_importer_utils.cc
+++ b/atom/common/importer/chrome_importer_utils.cc
@@ -65,6 +65,8 @@ bool ChromeImporterCanImport(const base::FilePath& profile,
     profile.Append(base::FilePath::StringType(FILE_PATH_LITERAL("History")));
   base::FilePath cookies =
     profile.Append(base::FilePath::StringType(FILE_PATH_LITERAL("Cookies")));
+  base::FilePath passwords =
+    profile.Append(base::FilePath::StringType(FILE_PATH_LITERAL("Login Data")));
 
   if (base::PathExists(bookmarks))
     *services_supported |= importer::FAVORITES;
@@ -72,6 +74,8 @@ bool ChromeImporterCanImport(const base::FilePath& profile,
     *services_supported |= importer::HISTORY;
   if (base::PathExists(cookies))
     *services_supported |= importer::COOKIES;
+  if (base::PathExists(passwords))
+    *services_supported |= importer::PASSWORDS;
 
   return *services_supported != importer::NONE;
 }

--- a/brave/utility/brave_profile_import_handler.cc
+++ b/brave/utility/brave_profile_import_handler.cc
@@ -8,10 +8,13 @@
 #include "brave/utility/brave_profile_import_handler.h"
 
 #include "base/bind.h"
+#include "base/command_line.h"
 #include "base/location.h"
 #include "base/memory/ptr_util.h"
 #include "base/memory/ref_counted.h"
 #include "base/single_thread_task_runner.h"
+#include "base/strings/string_util.h"
+#include "base/strings/utf_string_conversions.h"
 #include "base/threading/thread.h"
 #include "base/threading/thread_task_runner_handle.h"
 #include "build/build_config.h"
@@ -50,6 +53,12 @@ void BraveProfileImportHandler::StartImport(
   }
 
   items_to_import_ = items;
+
+  if (base::StartsWith(base::UTF16ToUTF8(source_profile.importer_name),
+                       "Chrome", base::CompareCase::SENSITIVE)) {
+    auto command_line = base::CommandLine::ForCurrentProcess();
+    command_line->AppendSwitch("import-chrome");
+  }
 
   // Create worker thread in which importer runs.
   import_thread_.reset(new base::Thread("import_thread"));

--- a/brave/utility/importer/chrome_importer.h
+++ b/brave/utility/importer/chrome_importer.h
@@ -14,6 +14,7 @@
 #include "base/compiler_specific.h"
 #include "base/files/file_path.h"
 #include "base/macros.h"
+#include "base/nix/xdg_util.h"
 #include "build/build_config.h"
 #include "chrome/utility/importer/importer.h"
 #include "components/favicon_base/favicon_usage_data.h"
@@ -40,9 +41,12 @@ class ChromeImporter : public Importer {
  private:
   ~ChromeImporter() override;
 
+  static base::nix::DesktopEnvironment GetDesktopEnvironment();
+
   void ImportBookmarks();
   void ImportHistory();
   void ImportCookies();
+  void ImportPasswords();
 
   // Multiple URLs can share the same favicon; this is a map
   // of URLs -> IconIDs that we load as a temporary step before

--- a/patches/master_patch.patch
+++ b/patches/master_patch.patch
@@ -1003,6 +1003,33 @@ index bc36a92f4ad97e84d65c5213acbb68fc89aae8d9..9567f7f130181a40917751fff899b439
  }
  
  // static
+diff --git a/components/os_crypt/keychain_password_mac.mm b/components/os_crypt/keychain_password_mac.mm
+index 2b38db266f9aa1f4141c8649c021042ede4e5589..ea0387b11f4b00f87596d738c152aa4cc43b2beb 100644
+--- a/components/os_crypt/keychain_password_mac.mm
++++ b/components/os_crypt/keychain_password_mac.mm
+@@ -7,6 +7,7 @@
+ #import <Security/Security.h>
+ 
+ #include "base/base64.h"
++#include "base/command_line.h"
+ #include "base/mac/mac_logging.h"
+ #include "base/rand_util.h"
+ #include "crypto/apple_keychain.h"
+@@ -61,6 +62,14 @@ const char KeychainPassword::account_name[] = "Chromium";
+ std::string KeychainPassword::GetPassword() const {
+   UInt32 password_length = 0;
+   void* password_data = NULL;
++  const char *service_name, *account_name;
++  if (base::CommandLine::ForCurrentProcess()->HasSwitch("import-chrome")) {
++    service_name = "Chrome Safe Storage";
++    account_name = "Chrome";
++  } else {
++    service_name = ::KeychainPassword::service_name;
++    account_name = ::KeychainPassword::account_name;
++  }
+   OSStatus error = keychain_.FindGenericPassword(
+       nullptr, strlen(service_name), service_name, strlen(account_name),
+       account_name, &password_length, &password_data, NULL);
 diff --git a/components/printing/common/print_messages.h b/components/printing/common/print_messages.h
 index 32b0451b60dd100d57ec67a31a94673f2ebd5359..ba98bd0c470bb155177bdd4fd0e268535f0c24d2 100644
 --- a/components/printing/common/print_messages.h


### PR DESCRIPTION
fixes https://github.com/brave/browser-laptop/issues/9434

Auditors: @bridiver, @bbondy, @diracdeltas, @bsclifton

Mac:
master password will store in Chrome/Chromium Safe Storage
so we will ask users to access it

Windows:
Using `CryptProtectData` and `CryptUnprotectData`
`Usually, the only user who can decrypt the data is a user with the same logon
credentials as the user who encrypted the data`

Linux:
Using NativeBackEnd.
gnome-keyring which will be removed soon is deprecated by libsecret
KDE has a bug traking it #238