### PR TITLE
Remove/replace process refs

### DIFF
--- a/atom/common/api/resources/event_emitter.js
+++ b/atom/common/api/resources/event_emitter.js
@@ -174,7 +174,7 @@ EventEmitter.prototype.emit = function emit(type) {
   if (!handler)
     return false;
 
-  if (domain && this !== process) {
+  if (domain) {
     domain.enter();
     needDomainExit = true;
   }
@@ -266,7 +266,7 @@ function _addListener(target, type, listener, prepend) {
         w.emitter = target;
         w.type = type;
         w.count = existing.length;
-        process.emitWarning(w);
+        console.warn(w);
       }
     }
   }


### PR DESCRIPTION
Removing references to `process` following discussion with @bridiver and @bbondy.

Fixes https://github.com/brave/browser-laptop/issues/9747