### PR TITLE
add muon.shared_memory to protected renderer processes

### DIFF
--- a/chromium_src/chrome/renderer/extensions/chrome_extensions_dispatcher_delegate.cc
+++ b/chromium_src/chrome/renderer/extensions/chrome_extensions_dispatcher_delegate.cc
@@ -254,6 +254,10 @@ void ChromeExtensionsDispatcherDelegate::RequireAdditionalModules(
         brave::URLBindings::API(context);
     muon->Set(v8::String::NewFromUtf8(context->isolate(), "url"), url);
 
+    v8::Local<v8::Object> shared_memory =
+        brave::SharedMemoryBindings::API(context);
+    muon->Set(v8::String::NewFromUtf8(context->isolate(), "shared_memory"),
+        shared_memory);
   }
 }
 


### PR DESCRIPTION
fix #269 

@bbondy I set this for 4.3 because it's meant to be a perf fix, but I can move to 4.4 if you want