### PR TITLE
Fall back to default popup value for extension if tab specific value not available

### DIFF
--- a/lib/browser/api/browser-actions.js
+++ b/lib/browser/api/browser-actions.js
@@ -13,10 +13,12 @@ const updateBrowserAction = (extensionId, details) => {
 
 const getBrowserAction = (extensionId, details) => {
   if (details.tabId) {
+    // return tab specific values (if there are any)
     if (browserActions[extensionId] && browserActions[extensionId][details.tabId]) {
       return browserActions[extensionId][details.tabId]
     }
   }
+  // return extension-wide details
   return browserActions[extensionId] || {}
 }
 
@@ -62,6 +64,6 @@ module.exports = {
   },
 
   getPopup: (extensionId, details) => {
-    return getBrowserAction(extensionId, details).popup
+    return getBrowserAction(extensionId, details).popup || getBrowserAction(extensionId, {}).popup
   }
 }


### PR DESCRIPTION
Fixes https://github.com/brave/browser-laptop/issues/10224

To be merged into Muon 4.3.x (for use with browser-laptop 0.18.x hotfix)

Auditors: @jonathansampson