### PR TITLE
Overrides user-data-dir by exe name on Windows

### DIFF
--- a/atom/app/atom_main_delegate.cc
+++ b/atom/app/atom_main_delegate.cc
@@ -156,6 +156,20 @@ base::FilePath InitializeUserDataDir() {
     command_line->AppendSwitchPath(switches::kUserDataDir, user_data_dir);
   }
 
+#if defined(OS_WIN)
+  if (user_data_dir.empty()) {
+    HMODULE hModule = GetModuleHandleW(NULL);
+    WCHAR path[MAX_PATH];
+    GetModuleFileNameW(hModule, path, MAX_PATH);
+    base::FilePath file_path(path);
+    base::FilePath::StringPieceType user_data_dir_string =
+      file_path.BaseName().RemoveExtension().value();
+    base::FilePath app_data_dir;
+    brave::GetDefaultAppDataDirectory(&app_data_dir);
+    user_data_dir = app_data_dir.Append(user_data_dir_string);
+  }
+#endif
+
   // next check the user-data-dir switch
   if (user_data_dir.empty() ||
       command_line->HasSwitch(switches::kUserDataDir)) {

--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -2473,8 +2473,9 @@ void WebContents::OnRendererMessageSync(const base::string16& channel,
   EmitWithSender(base::UTF16ToUTF8(channel), web_contents(), message, args);
 }
 
-void WebContents::OnRendererMessageShared(const base::string16& channel,
-                                         const base::SharedMemoryHandle& handle) {
+void
+WebContents::OnRendererMessageShared(const base::string16& channel,
+                                     const base::SharedMemoryHandle& handle) {
   std::vector<v8::Local<v8::Value>> args = {
     mate::StringToV8(isolate(), channel),
     brave::SharedMemoryWrapper::CreateFrom(isolate(), handle).ToV8(),


### PR DESCRIPTION
It will be used for different channels release. ex.
BraveNightly.exe will use BraveNightly as user-data-dir name
BraveDeveloper.exe -> BraveDeveloper
BraveBeta.exe -> BraveBeta
brave.exe -> brave
