### PR TITLE
Implements chrome.windows.remove method

### DIFF
--- a/atom/common/api/resources/windows_bindings.js
+++ b/atom/common/api/resources/windows_bindings.js
@@ -1,5 +1,5 @@
 var binding = require('binding').Binding.create('windows')
-
+var lastError = require('lastError')
 var ipc = require('ipc_utils')
 
 var id = 1;
@@ -13,7 +13,15 @@ binding.registerCustomHook(function (bindingsAPI, extensionId) {
   })
 
   apiFunctions.setHandleRequest('remove', function (windowId, cb) {
-    console.warn('chrome.windows.remove is not supported yet')
+    var responseId = ++id
+    cb && ipc.once('chrome-windows-remove-response-' + responseId, function (evt, error) {
+      if (error) {
+        lastError.run('windows.remove', error, '', cb)
+      } else {
+        cb()
+      }
+    })
+    ipc.send('chrome-windows-remove', responseId, windowId)
   })
 
   apiFunctions.setHandleRequest('get', function (windowId, getInfo, cb) {

--- a/lib/browser/api/extensions.js
+++ b/lib/browser/api/extensions.js
@@ -183,6 +183,18 @@ var updateWindow = function (windowId, updateInfo) {
   }
 }
 
+var removeWindow = function (windowId, cb) {
+  let error
+  let win = BrowserWindow.fromId(windowId)
+  if (win) {
+    win.close()
+  } else {
+    error = 'chrome.windows.remove could not find windowId ' + windowId
+    console.warn(error)
+  }
+  cb(error)
+}
+
 const createTab = function (createProperties, cb) {
   let windowId = createProperties.windowId || -2
   let win = null
@@ -651,6 +663,19 @@ ipcMain.on('chrome-windows-get-all', function (evt, responseId, getInfo) {
 ipcMain.on('chrome-windows-update', function (evt, responseId, windowId, updateInfo) {
   var response = updateWindow(windowId, updateInfo)
   evt.sender.send('chrome-windows-update-response-' + responseId, response)
+})
+
+ipcMain.on('chrome-windows-remove', function (evt, responseId, windowId) {
+  const cb = (error) => {
+    if (!evt.sender.isDestroyed()) {
+      evt.sender.send('chrome-windows-remove-response-' + responseId, error)
+    }
+  }
+  try {
+    removeWindow(windowId, cb)
+  } catch (e) {
+    cb(null, e.message)
+  }
 })
 
 // chrome.browserAction


### PR DESCRIPTION
Implements the `chrome.windows.remove` method.

Fixes https://github.com/brave/browser-laptop/issues/8678