### PR TITLE
Use HostNoBrackets instead of host for hostname in muon.url.parse

### DIFF
--- a/brave/common/extensions/url_bindings.cc
+++ b/brave/common/extensions/url_bindings.cc
@@ -413,7 +413,7 @@ void URLBindings::Parse(
       dict.Set("auth", gurl.username() + (gurl.has_password()
         ? ":" + gurl.password() : ""));
     dict.Set("hash", (gurl.has_ref() ? "#" : "") + gurl.ref());
-    dict.Set("hostname", gurl.host());
+    dict.Set("hostname", gurl.HostNoBrackets());
     dict.Set("host", gurl.host() + (gurl.has_port() ? ":" + gurl.port() : ""));
     dict.Set("href", gurl.possibly_invalid_spec());
     dict.Set("path", gurl.PathForRequest());


### PR DESCRIPTION
To match behavior of node url.parse on ipv6 addresses
Partial fix for https://github.com/brave/browser-laptop/issues/10825