### PR TITLE
Expose missing spell checking interface

### DIFF
--- a/brave/browser/brave_content_browser_client.cc
+++ b/brave/browser/brave_content_browser_client.cc
@@ -234,6 +234,15 @@ void BraveContentBrowserClient::ExposeInterfacesToRenderer(
   // gap between the preparation and the execution of that IPC.
   associated_registry->AddInterface(
       base::Bind(&CacheStatsRecorder::Create, render_process_host->GetID()));
+
+  scoped_refptr<base::SingleThreadTaskRunner> ui_task_runner =
+      content::BrowserThread::GetTaskRunnerForThread(
+          content::BrowserThread::UI);
+#if BUILDFLAG(ENABLE_SPELLCHECK)
+  registry->AddInterface(
+      base::Bind(&SpellCheckHostImpl::Create, render_process_host->GetID()),
+      ui_task_runner);
+#endif
 }
 
 void BraveContentBrowserClient::BindInterfaceRequest(

--- a/brave/browser/brave_content_browser_client.cc
+++ b/brave/browser/brave_content_browser_client.cc
@@ -243,6 +243,10 @@ void BraveContentBrowserClient::ExposeInterfacesToRenderer(
       base::Bind(&SpellCheckHostImpl::Create, render_process_host->GetID()),
       ui_task_runner);
 #endif
+#if BUILDFLAG(HAS_SPELLCHECK_PANEL)
+  registry->AddInterface(base::Bind(&SpellCheckPanelHostImpl::Create),
+      ui_task_runner);
+#endif
 }
 
 void BraveContentBrowserClient::BindInterfaceRequest(


### PR DESCRIPTION
This should fix https://github.com/brave/browser-laptop/issues/10849. Tested on Linux and Windows.