### PR TITLE
Prevent window from being closed when before-quit is default prevented on non MacOs

### DIFF
--- a/atom/browser/extensions/tab_helper.cc
+++ b/atom/browser/extensions/tab_helper.cc
@@ -253,6 +253,10 @@ void TabHelper::WillCloseWindow(bool* prevent_default) {
     browser()->window()->Deactivate();
     browser()->window()->Hide();
   }
+  if (!browser_shutdown::IsTryingToQuit() &&
+      BrowserList::GetInstance()->size() == 1) {
+    *prevent_default = true;
+  }
 }
 
 void TabHelper::OnBrowserRemoved(Browser* browser) {


### PR DESCRIPTION
required by https://github.com/brave/browser-laptop/pull/10687

Auditors: @bridiver, @bsclifton, @bbondy