### PR TITLE
don’t unregister guest events on crash

### DIFF
--- a/lib/browser/guest-view-manager.js
+++ b/lib/browser/guest-view-manager.js
@@ -19,7 +19,6 @@ let supportedWebViewEvents = [
   'did-navigate-in-page',
   'security-style-changed',
   'close',
-  'crashed',
   'gpu-crashed',
   'plugin-crashed',
   'will-destroy',
@@ -69,7 +68,7 @@ const registerGuest = function (guest, embedder) {
         return
 
       let forceSend = false
-      if (['destroyed', 'crashed', 'did-detach', 'will-detach'].includes(event)) {
+      if (['destroyed', 'did-detach', 'will-detach'].includes(event)) {
         delete guests[tabId]
         forceSend = true
       }

--- a/lib/renderer/web-view/guest-view-internal.js
+++ b/lib/renderer/web-view/guest-view-internal.js
@@ -17,7 +17,6 @@ var WEB_VIEW_EVENTS = {
   'did-navigate': ['url', 'isRendererInitiated'],
   'did-navigate-in-page': ['url', 'isMainFrame'],
   'close': [],
-  'crashed': [],
   'gpu-crashed': [],
   'plugin-crashed': ['name', 'version'],
   'will-destroy': [],


### PR DESCRIPTION
prereq for https://github.com/brave/browser-laptop/issues/8574