### PR TITLE
Overrides service_manager::Service::OnStart() for BraveProfileImportService

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -274,6 +274,8 @@ source_set("utility") {
     "brave/utility/importer/brave_external_process_importer_bridge.h",
     "brave/utility/importer/brave_profile_import_impl.cc",
     "brave/utility/importer/brave_profile_import_impl.h",
+    "brave/utility/importer/brave_profile_import_service.cc",
+    "brave/utility/importer/brave_profile_import_service.h",
     "brave/utility/importer/firefox_importer.cc",
     "brave/utility/importer/firefox_importer.h",
     "brave/utility/importer/importer_creator.cc",

--- a/atom/utility/atom_content_utility_client.cc
+++ b/atom/utility/atom_content_utility_client.cc
@@ -10,10 +10,10 @@
 #include "base/files/file_path.h"
 #include "base/memory/ref_counted.h"
 #include "base/time/time.h"
+#include "brave/utility/importer/brave_profile_import_service.h"
 #include "chrome/common/importer/profile_import.mojom.h"
 #include "chrome/common/resource_usage_reporter.mojom.h"
 #include "chrome/utility/extensions/extensions_handler.h"
-#include "chrome/utility/importer/profile_import_service.h"
 #include "chrome/utility/utility_message_handler.h"
 #include "content/public/common/content_switches.h"
 #include "content/public/common/service_manager_connection.h"
@@ -134,7 +134,7 @@ void AtomContentUtilityClient::RegisterServices(
     AtomContentUtilityClient::StaticServiceMap* services) {
   service_manager::EmbeddedServiceInfo profile_import_info;
   profile_import_info.factory =
-    base::Bind(&ProfileImportService::CreateService);
+    base::Bind(&BraveProfileImportService::CreateService);
   services->emplace(chrome::mojom::kProfileImportServiceName,
                     profile_import_info);
 }

--- a/brave/utility/importer/brave_profile_import_service.cc
+++ b/brave/utility/importer/brave_profile_import_service.cc
@@ -1,0 +1,55 @@
+// Copyright (c) 2017 The Brave Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "brave/utility/importer/brave_profile_import_service.h"
+
+#include <string>
+#include <utility>
+
+#include "brave/utility/importer/brave_profile_import_impl.h"
+#include "build/build_config.h"
+#include "mojo/public/cpp/bindings/strong_binding.h"
+
+#if defined(OS_MACOSX)
+#include <stdlib.h>
+
+#include "chrome/common/importer/firefox_importer_utils.h"
+#endif
+
+namespace {
+
+void OnProfileImportRequest(
+    service_manager::ServiceContextRefFactory* ref_factory,
+    chrome::mojom::ProfileImportRequest request) {
+  mojo::MakeStrongBinding(
+      base::MakeUnique<BraveProfileImportImpl>(ref_factory->CreateRef()),
+      std::move(request));
+}
+
+}  // namespace
+
+BraveProfileImportService::BraveProfileImportService()
+    : ProfileImportService() {}
+
+BraveProfileImportService::~BraveProfileImportService() {}
+
+std::unique_ptr<service_manager::Service>
+BraveProfileImportService::CreateService() {
+  return base::MakeUnique<BraveProfileImportService>();
+}
+
+void BraveProfileImportService::OnStart() {
+  ref_factory_.reset(new service_manager::ServiceContextRefFactory(
+      base::Bind(&service_manager::ServiceContext::RequestQuit,
+                 base::Unretained(context()))));
+  registry_.AddInterface(
+      base::Bind(&OnProfileImportRequest, ref_factory_.get()));
+
+#if defined(OS_MACOSX)
+  std::string dylib_path = GetFirefoxDylibPath().value();
+  if (!dylib_path.empty())
+    ::setenv("DYLD_FALLBACK_LIBRARY_PATH", dylib_path.c_str(),
+             1 /* overwrite */);
+#endif
+}

--- a/brave/utility/importer/brave_profile_import_service.h
+++ b/brave/utility/importer/brave_profile_import_service.h
@@ -1,0 +1,27 @@
+// Copyright (c) 2017 The Brave Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+//
+#ifndef BRAVE_UTILITY_IMPORTER_BRAVE_PROFILE_IMPORT_SERVICE_H_
+#define BRAVE_UTILITY_IMPORTER_BRAVE_PROFILE_IMPORT_SERVICE_H_
+
+#include <memory>
+
+#include "chrome/utility/importer/profile_import_service.h"
+
+class BraveProfileImportService : public ProfileImportService {
+ public:
+  BraveProfileImportService();
+  ~BraveProfileImportService() override;
+
+  // Factory method for creating the service.
+  static std::unique_ptr<service_manager::Service> CreateService();
+
+ private:
+  // Lifescycle events that occur after the service has started to spinup.
+  void OnStart() override;
+
+  DISALLOW_COPY_AND_ASSIGN(BraveProfileImportService);
+};
+
+#endif  // BRAVE_UTILITY_IMPORTER_BRAVE_PROFILE_IMPORT_SERVICE_H_

--- a/patches/master_patch.patch
+++ b/patches/master_patch.patch
@@ -1080,6 +1080,18 @@ index 4fb2499aa536d3618df2bbc4072fb23420f42c2e..65b6268d8d85545799a6a47e59b4adb7
    // chrome::mojom::ProfileImport:
    void StartImport(const importer::SourceProfile& source_profile,
                     uint16_t items,
+diff --git a/chrome/utility/importer/profile_import_service.h b/chrome/utility/importer/profile_import_service.h
+index c4c5f83886574956b3abdfa77a07500a2ee6de9e..edbfde3c41a1e38bcdedd09aaa41d8a1ab3ab03b 100644
+--- a/chrome/utility/importer/profile_import_service.h
++++ b/chrome/utility/importer/profile_import_service.h
+@@ -24,6 +24,7 @@ class ProfileImportService : public service_manager::Service {
+                        mojo::ScopedMessagePipeHandle interface_pipe) override;
+ 
+  private:
++  friend class BraveProfileImportService;
+   // State needed to manage service lifecycle and lifecycle of bound clients.
+   std::unique_ptr<service_manager::ServiceContextRefFactory> ref_factory_;
+   service_manager::BinderRegistry registry_;
 diff --git a/components/crash/content/app/breakpad_linux.cc b/components/crash/content/app/breakpad_linux.cc
 index 2199920ee79326a1dcd79e44c7fc33753b2d7262..f82a9936e0f45af3b13c7a033b7d957a2f62b0a7 100644
 --- a/components/crash/content/app/breakpad_linux.cc


### PR DESCRIPTION
This will fix import cookies/passwords from Chrome on chromium 62 or you will see `Importer could not be created.` from `chrome/utility/importer/profile_import_impl.cc`

Auditors: @bridiver, @bbondy