### PR TITLE
Don't call OSCrypt::IsEncryptionAvailable which will directly get password before SetConfig()

### DIFF
--- a/brave/utility/importer/chrome_importer.cc
+++ b/brave/utility/importer/chrome_importer.cc
@@ -288,12 +288,9 @@ void ChromeImporter::ImportCookies() {
     net::CookieCryptoDelegate* delegate =
       cookie_config::GetCookieCryptoDelegate();
     std::string value;
-#if defined(OS_LINUX)
-    if (!encrypted_value.empty() && delegate &&
-        OSCrypt::IsEncryptionAvailable()) {
-      OSCrypt::SetConfig(base::MakeUnique<os_crypt::Config>());
-#else
     if (!encrypted_value.empty() && delegate) {
+#if defined(OS_LINUX)
+      OSCrypt::SetConfig(base::MakeUnique<os_crypt::Config>());
 #endif
       if (!delegate->DecryptString(encrypted_value, &value)) {
         continue;


### PR DESCRIPTION
fix https://github.com/brave/browser-laptop/issues/11280 again

Auditors: @bridiver, @bbondy