### PR TITLE
view can NULL, but no need to set it to the default when it’s already…

### DIFF
--- a/brave/browser/guest_view/tab_view/tab_view_guest.cc
+++ b/brave/browser/guest_view/tab_view/tab_view_guest.cc
@@ -367,12 +367,6 @@ void TabViewGuest::GuestReady() {
   // we don't use guest only processes and don't want those limitations
   CHECK(!web_contents()->GetRenderProcessHost()->IsForGuestsOnly());
 
-  web_contents()
-      ->GetRenderViewHost()
-      ->GetWidget()
-      ->GetView()
-      ->SetBackgroundColorToDefault();
-
   api_web_contents_->Emit("guest-ready",
       extensions::TabHelper::IdForTab(web_contents()), guest_instance_id());
 }


### PR DESCRIPTION
… the default

```
Operating system: Mac OS X
                  10.12.6 16G29
CPU: amd64
     family 6 model 78 stepping 3
     4 CPUs

Crash reason:  EXC_BAD_ACCESS / KERN_INVALID_ADDRESS
Crash address: 0x0
Process uptime: 45422 seconds

Thread 0 (crashed)
 0  Brave Framework!brave::TabViewGuest::GuestReady() [tab_view_guest.cc : 374 + 0x0]
    rax = 0x0000000000000000   rdx = 0x000000000000001e
    rcx = 0x000000010af22d20   rbx = 0x00007fff5a68d7e8
    rsi = 0x00007fff5a68d7c8   rdi = 0x00007fd0dcef6a40
    rbp = 0x00007fff5a68d7b0   rsp = 0x00007fff5a68d780
     r8 = 0x000019dbbb0727e9    r9 = 0x0000000000000004
    r10 = 0x0000000000000140   r11 = 0x0000000000000014
    r12 = 0x00007fd0daf08760   r13 = 0x00007fff5a68db00
    r14 = 0x00007fd0dea368d0   r15 = 0x00007fd0dea368f8
    rip = 0x0000000105e48f8f
    Found by: given as instruction pointer in context
 1  Brave Framework!content::WebContentsImpl::RenderViewReady(content::RenderViewHost*) [web_contents_impl.cc : 4753 + 0x6]
    rbp = 0x00007fff5a68d820   rsp = 0x00007fff5a68d7c0
    rip = 0x000000010631654e
    Found by: previous frame's frame pointer
 2  Brave Framework!content::(anonymous namespace)::RenderProcessHostIsReadyObserver::CallTask() [callback.h : 91 + 0x3]
    rbp = 0x00007fff5a68d850   rsp = 0x00007fff5a68d830
    rip = 0x0000000106210af6
    Found by: previous frame's frame pointer
 3  Brave Framework!base::debug::TaskAnnotator::RunTask(char const*, base::PendingTask*) [callback.h : 91 + 0x3]
    rbp = 0x00007fff5a68d990   rsp = 0x00007fff5a68d860
    rip = 0x00000001070ddc72
    Found by: previous frame's frame pointer
 4  Brave Framework!base::MessageLoop::RunTask(base::PendingTask*) [message_loop.cc : 422 + 0xf]
    rbp = 0x00007fff5a68da60   rsp = 0x00007fff5a68d9a0
    rip = 0x00000001071017ab
    Found by: previous frame's frame pointer
 5  Brave Framework!base::MessageLoop::DeferOrRunPendingTask(base::PendingTask) [message_loop.cc : 433 + 0xb]
    rbp = 0x00007fff5a68da80   rsp = 0x00007fff5a68da70
    rip = 0x0000000107101b95
    Found by: previous frame's frame pointer
 6  Brave Framework!base::MessageLoop::DoWork() [message_loop.cc : 540 + 0xb]
    rbp = 0x00007fff5a68dc10   rsp = 0x00007fff5a68da90
    rip = 0x0000000107101e69
    Found by: previous frame's frame pointer
 7  Brave Framework!base::MessagePumpCFRunLoopBase::RunWork() [message_pump_mac.mm : 421 + 0x6]
    rbp = 0x00007fff5a68dc40   rsp = 0x00007fff5a68dc20
    rip = 0x00000001071052ea
    Found by: previous frame's frame pointer
 8  Brave Framework!base::mac::CallWithEHFrame(void () block_pointer) + 0xa
    rbp = 0x00007fff5a68dc50   rsp = 0x00007fff5a68dc50
    rip = 0x00000001070f615a
    Found by: previous frame's frame pointer
 9  Brave Framework!base::MessagePumpCFRunLoopBase::RunWorkSource(void*) [message_pump_mac.mm : 397 + 0x5]
    rbp = 0x00007fff5a68dc90   rsp = 0x00007fff5a68dc60
    rip = 0x0000000107104c0f
    Found by: previous frame's frame pointer
10  CoreFoundation + 0xa7321
    rbp = 0x00007fff5a68dca0   rsp = 0x00007fff5a68dca0
    rip = 0x00007fffb096d321
    Found by: previous frame's frame pointer
11  CoreFoundation + 0x8821d
    rbp = 0x00007fff5a68dd00   rsp = 0x00007fff5a68dcb0
    rip = 0x00007fffb094e21d
    Found by: previous frame's frame pointer
12  CoreFoundation + 0x87716
    rbp = 0x00007fff5a68e9f0   rsp = 0x00007fff5a68dd10
    rip = 0x00007fffb094d716
    Found by: previous frame's frame pointer
13  CoreFoundation + 0x87114
    rbp = 0x00007fff5a68ea80   rsp = 0x00007fff5a68ea00
    rip = 0x00007fffb094d114
    Found by: previous frame's frame pointer
14  HIToolbox + 0x30ebc
    rbp = 0x00007fff5a68eac0   rsp = 0x00007fff5a68ea90
    rip = 0x00007fffafeadebc
    Found by: previous frame's frame pointer
15  HIToolbox + 0x30cf1
    rbp = 0x00007fff5a68eb40   rsp = 0x00007fff5a68ead0
    rip = 0x00007fffafeadcf1
    Found by: previous frame's frame pointer
16  HIToolbox + 0x30b26
    rbp = 0x00007fff5a68eb60   rsp = 0x00007fff5a68eb50
    rip = 0x00007fffafeadb26
    Found by: previous frame's frame pointer
17  AppKit + 0x46a54
    rbp = 0x00007fff5a68ef80   rsp = 0x00007fff5a68eb70
    rip = 0x00007fffae446a54
    Found by: previous frame's frame pointer
18  AppKit + 0x7c27ee
    rbp = 0x00007fff5a68f230   rsp = 0x00007fff5a68ef90
    rip = 0x00007fffaebc27ee
    Found by: previous frame's frame pointer
19  AppKit + 0x3b3db
    rbp = 0x00007fff5a68f320   rsp = 0x00007fff5a68f240
    rip = 0x00007fffae43b3db
    Found by: previous frame's frame pointer
20  Brave Framework!base::MessagePumpNSApplication::DoRun(base::MessagePump::Delegate*) [message_pump_mac.mm : 749 + 0xd]
    rbp = 0x00007fff5a68f380   rsp = 0x00007fff5a68f330
    rip = 0x0000000107105b1e
    Found by: previous frame's frame pointer
21  Brave Framework!base::MessagePumpCFRunLoopBase::Run(base::MessagePump::Delegate*) [message_pump_mac.mm : 141 + 0xc]
    rbp = 0x00007fff5a68f3b0   rsp = 0x00007fff5a68f390
    rip = 0x000000010710451c
    Found by: previous frame's frame pointer
22  Brave Framework!<name omitted> [run_loop.cc : 111 + 0x5]
    rbp = 0x00007fff5a68f440   rsp = 0x00007fff5a68f3c0
    rip = 0x0000000107120c43
    Found by: previous frame's frame pointer
23  Brave Framework!content::BrowserMainLoop::MainMessageLoopRun() [browser_main_loop.cc : 1696 + 0x8]
    rbp = 0x00007fff5a68f4b0   rsp = 0x00007fff5a68f450
    rip = 0x0000000105f68bef
    Found by: previous frame's frame pointer
24  Brave Framework!content::BrowserMainLoop::RunMainMessageLoopParts() [browser_main_loop.cc : 1172 + 0x8]
    rbp = 0x00007fff5a68f4e0   rsp = 0x00007fff5a68f4c0
    rip = 0x0000000105f68a10
    Found by: previous frame's frame pointer
25  Brave Framework!content::BrowserMainRunnerImpl::Run() [browser_main_runner.cc : 142 + 0x5]
    rbp = 0x00007fff5a68f500   rsp = 0x00007fff5a68f4f0
    rip = 0x0000000105f6b0c2
    Found by: previous frame's frame pointer
26  Brave Framework!content::BrowserMain(content::MainFunctionParams const&) [browser_main.cc : 46 + 0x9]
    rbp = 0x00007fff5a68f530   rsp = 0x00007fff5a68f510
    rip = 0x0000000105f64a6c
    Found by: previous frame's frame pointer
27  Brave Framework!content::ContentMainRunnerImpl::Run() [content_main_runner.cc : 686 + 0x8]
    rbp = 0x00007fff5a68f5a0   rsp = 0x00007fff5a68f540
    rip = 0x00000001070c4720
    Found by: previous frame's frame pointer
28  Brave Framework!service_manager::Main(service_manager::MainParams const&) [main.cc : 469 + 0xa]
    rbp = 0x00007fff5a68fa20   rsp = 0x00007fff5a68f5b0
    rip = 0x00000001084fe124
    Found by: previous frame's frame pointer
29  Brave Framework!content::ContentMain(content::ContentMainParams const&) [content_main.cc : 19 + 0x8]
    rbp = 0x00007fff5a68faa0   rsp = 0x00007fff5a68fa30
    rip = 0x00000001070c3d04
    Found by: previous frame's frame pointer
30  Brave Framework!ChromeMain [atom_main.cc : 94 + 0x5]
    rbp = 0x00007fff5a68fbe0   rsp = 0x00007fff5a68fab0
    rip = 0x0000000105a65f0d
    Found by: previous frame's frame pointer
31  Brave!main [chrome_exe_main_mac.c : 85 + 0x8]
    rbp = 0x00007fff5a68fc30   rsp = 0x00007fff5a68fbf0
    rip = 0x0000000105570dba
    Found by: previous frame's frame pointer
32  libdyld.dylib + 0x5235
    rbp = 0x00007fff5a68fc40   rsp = 0x00007fff5a68fc40
    rip = 0x00007fffc60d5235
    Found by: previous frame's frame pointer
```
