### PR TITLE
Draft implementation of chrome.tabs.duplicate, #7458.

### DIFF
--- a/atom/common/api/resources/tabs_bindings.js
+++ b/atom/common/api/resources/tabs_bindings.js
@@ -213,6 +213,18 @@ binding.registerCustomHook(function(bindingsAPI, extensionId) {
     ipc.send('chrome-tabs-create', responseId, createProperties)
   })
 
+  apiFunctions.setHandleRequest('duplicate', function (tabId, cb) {
+    var responseId = ipc.guid()
+    cb && ipc.once('chrome-tabs-duplicate-response-' + responseId, function (evt, dtab, error) {
+      if (error) {
+        lastError.run('tabs.duplicate', error, '', () => { cb(null) })
+      } else {
+        cb(dtab)
+      }
+    })
+    ipc.send('chrome-tabs-duplicate', responseId, tabId)
+  })
+
   apiFunctions.setHandleRequest('executeScript', function (tabId, details, cb) {
     var responseId = ipc.guid()
     tabId = tabId || -2

--- a/lib/browser/api/extensions.js
+++ b/lib/browser/api/extensions.js
@@ -259,6 +259,25 @@ const createTab = function (createProperties, cb) {
   }
 }
 
+const duplicateTab = function (tabId, cb) {
+  try {
+    let tab = getWebContentsForTab(tabId)
+    // XXX What to do if not there?
+    tab._clone(
+      (dtab) => {
+        if (dtab) {
+          cb(dtab)
+        } else {
+          cb(null, 'An unexpected error occurred')
+        }
+      }
+    )
+  } catch (e) {
+    console.error(e)
+    cb(null, 'An unexpected error occurred: ' + e.message)
+  }
+}
+
 const removeTabs = function (tabIds) {
   for (let tabId of tabIds) {
     var tabContents = getWebContentsForTab(tabId)
@@ -470,6 +489,20 @@ ipcMain.on('chrome-tabs-create', function (evt, responseId, createProperties) {
   }
   try {
     createTab(createProperties, cb)
+  } catch (e) {
+    cb(null, e.message)
+  }
+})
+
+ipcMain.on('chrome-tabs-duplicate', function (evt, responseId, tabId) {
+  const cb = (dtab, error) => {
+    if (!evt.sender.isDestroyed()) {
+      let dtabValue = error ? null : dtab.tabValue()
+      evt.sender.send('chrome-tabs-duplicate-response-' + responseId, dtabValue, error)
+    }
+  }
+  try {
+    duplicateTab(tabId, cb)
   } catch (e) {
     cb(null, e.message)
   }


### PR DESCRIPTION
May not duplicate everything one might want duplicated -- it is a first-order approximation.