### PR TITLE
Implement muon.crypto.encryptString/decryptString API

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -211,6 +211,8 @@ source_set("common") {
     "brave/common/extensions/asar_source_map.h",
     "brave/common/extensions/crash_reporter_bindings.cc",
     "brave/common/extensions/crash_reporter_bindings.h",
+    "brave/common/extensions/crypto_bindings.cc",
+    "brave/common/extensions/crypto_bindings.h",
     "brave/common/extensions/file_bindings.cc",
     "brave/common/extensions/file_bindings.h",
     "brave/common/extensions/path_bindings.cc",

--- a/atom/browser/javascript_environment.cc
+++ b/atom/browser/javascript_environment.cc
@@ -18,6 +18,7 @@
 #include "base/path_service.h"
 #include "base/threading/thread_task_runner_handle.h"
 #include "brave/common/extensions/crash_reporter_bindings.h"
+#include "brave/common/extensions/crypto_bindings.h"
 #include "brave/common/extensions/file_bindings.h"
 #include "brave/common/extensions/path_bindings.h"
 #include "brave/common/extensions/shared_memory_bindings.h"
@@ -179,6 +180,10 @@ JavascriptEnvironment::JavascriptEnvironment()
   v8::Local<v8::Object> crash_reporter =
       brave::CrashReporterBindings::API(script_context_.get());
   muon->Set(v8::String::NewFromUtf8(isolate_, "crashReporter"), crash_reporter);
+
+  v8::Local<v8::Object> crypto =
+      brave::CryptoBindings::API(script_context_.get());
+  muon->Set(v8::String::NewFromUtf8(isolate_, "crypto"), crypto);
 }
 
 JavascriptEnvironment::~JavascriptEnvironment() {

--- a/brave/common/extensions/crypto_bindings.cc
+++ b/brave/common/extensions/crypto_bindings.cc
@@ -63,7 +63,8 @@ void CryptoBindings::EncryptString(
     base::Base64Encode(ciphertext, &encoded_cipher);
     args.GetReturnValue().Set(gin::ConvertToV8(isolate, encoded_cipher));
   } else {
-    args.GetReturnValue().Set(gin::ConvertToV8(isolate, plaintext));
+    isolate->ThrowException(v8::String::NewFromUtf8(
+        isolate, "`EncryptString` failed"));
   }
 }
 
@@ -78,14 +79,16 @@ void CryptoBindings::DecryptString(
   std::string encoded_cipher = *v8::String::Utf8Value(args[0]);
   std::string ciphertext;
   if (!base::Base64Decode(encoded_cipher, &ciphertext)) {
-    args.GetReturnValue().Set(gin::ConvertToV8(isolate, encoded_cipher));
+    isolate->ThrowException(v8::String::NewFromUtf8(
+        isolate, "ciphertext should be in base64 format"));
     return;
   }
   std::string plaintext;
   if (OSCrypt::DecryptString(ciphertext, &plaintext)) {
     args.GetReturnValue().Set(gin::ConvertToV8(isolate, plaintext));
   } else {
-    args.GetReturnValue().Set(gin::ConvertToV8(isolate, encoded_cipher));
+    isolate->ThrowException(v8::String::NewFromUtf8(
+        isolate, "`DecryptString` failed"));
   }
 }
 

--- a/brave/common/extensions/crypto_bindings.cc
+++ b/brave/common/extensions/crypto_bindings.cc
@@ -1,0 +1,92 @@
+// Copyright (c) 2017 The Brave Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "brave/common/extensions/crypto_bindings.h"
+
+#include <memory>
+#include <string>
+
+#include "base/base64.h"
+#include "components/os_crypt/os_crypt.h"
+#include "extensions/renderer/script_context.h"
+#include "extensions/renderer/v8_helpers.h"
+#include "gin/converter.h"
+#include "v8/include/v8.h"
+
+namespace brave {
+
+CryptoBindings::CryptoBindings(
+        extensions::ScriptContext* context)
+    : extensions::ObjectBackedNativeHandler(context) {
+  RouteFunction("EncryptString",
+      base::Bind(&CryptoBindings::EncryptString,
+          base::Unretained(this)));
+  RouteFunction("DecryptString",
+      base::Bind(&CryptoBindings::DecryptString,
+          base::Unretained(this)));
+}
+
+CryptoBindings::~CryptoBindings() {
+}
+
+// static
+v8::Local<v8::Object> CryptoBindings::API(
+    extensions::ScriptContext* context) {
+  context->module_system()->RegisterNativeHandler(
+    "muon_crypto", std::unique_ptr<extensions::NativeHandler>(
+        new CryptoBindings(context)));
+
+  v8::Local<v8::Object> crypto = v8::Object::New(context->isolate());
+  context->module_system()->SetNativeLazyField(
+      crypto,
+      "encryptString", "muon_crypto", "EncryptString");
+  context->module_system()->SetNativeLazyField(
+      crypto,
+      "decryptString", "muon_crypto", "DecryptString");
+  return crypto;
+}
+
+void CryptoBindings::EncryptString(
+    const v8::FunctionCallbackInfo<v8::Value>& args) {
+  auto isolate = context()->isolate();
+  if (args.Length() != 1) {
+    isolate->ThrowException(v8::String::NewFromUtf8(
+        isolate, "`plaintext` is a required field"));
+    return;
+  }
+
+  std::string plaintext = *v8::String::Utf8Value(args[0]);
+  std::string ciphertext;
+  if (OSCrypt::EncryptString(plaintext, &ciphertext)) {
+    std::string encoded_cipher;
+    base::Base64Encode(ciphertext, &encoded_cipher);
+    args.GetReturnValue().Set(gin::ConvertToV8(isolate, encoded_cipher));
+  } else {
+    args.GetReturnValue().Set(gin::ConvertToV8(isolate, plaintext));
+  }
+}
+
+void CryptoBindings::DecryptString(
+    const v8::FunctionCallbackInfo<v8::Value>& args) {
+  auto isolate = context()->isolate();
+  if (args.Length() != 1) {
+    isolate->ThrowException(v8::String::NewFromUtf8(
+        isolate, "`ciphertext` is a required field"));
+    return;
+  }
+  std::string encoded_cipher = *v8::String::Utf8Value(args[0]);
+  std::string ciphertext;
+  if (!base::Base64Decode(encoded_cipher, &ciphertext)) {
+    args.GetReturnValue().Set(gin::ConvertToV8(isolate, encoded_cipher));
+    return;
+  }
+  std::string plaintext;
+  if (OSCrypt::DecryptString(ciphertext, &plaintext)) {
+    args.GetReturnValue().Set(gin::ConvertToV8(isolate, plaintext));
+  } else {
+    args.GetReturnValue().Set(gin::ConvertToV8(isolate, encoded_cipher));
+  }
+}
+
+}  // namespace brave

--- a/brave/common/extensions/crypto_bindings.h
+++ b/brave/common/extensions/crypto_bindings.h
@@ -1,0 +1,31 @@
+// Copyright (c) 2017 The Brave Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef BRAVE_COMMON_EXTENSIONS_CRYPTO_BINDINGS_H_
+#define BRAVE_COMMON_EXTENSIONS_CRYPTO_BINDINGS_H_
+
+#include "base/compiler_specific.h"
+#include "base/macros.h"
+#include "extensions/renderer/module_system.h"
+#include "extensions/renderer/object_backed_native_handler.h"
+#include "v8/include/v8.h"
+
+namespace brave {
+
+class CryptoBindings : public extensions::ObjectBackedNativeHandler {
+ public:
+  explicit CryptoBindings(extensions::ScriptContext* context);
+  ~CryptoBindings() override;
+
+  static v8::Local<v8::Object> API(extensions::ScriptContext* context);
+ private:
+  void EncryptString(const v8::FunctionCallbackInfo<v8::Value>& args);
+  void DecryptString(const v8::FunctionCallbackInfo<v8::Value>& args);
+
+  DISALLOW_COPY_AND_ASSIGN(CryptoBindings);
+};
+
+}  // namespace brave
+
+#endif  // BRAVE_COMMON_EXTENSIONS_CRYPTO_BINDINGS_H_


### PR DESCRIPTION
master key is same as built-in password manager/cookies
Using base64 to encode non ASCII characters

fix https://github.com/brave/browser-laptop/issues/10705

Auditors: @bridiver, @diracdeltas, @bbondy