### PR TITLE
don’t handle renderer messages when webcontents is being destroyed

### DIFF
--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -1434,6 +1434,9 @@ void WebContents::DevToolsClosed() {
 }
 
 bool WebContents::OnMessageReceived(const IPC::Message& message) {
+  if (is_being_destroyed_)
+    return false;
+
   bool handled = true;
   IPC_BEGIN_MESSAGE_MAP(WebContents, message)
     IPC_MESSAGE_HANDLER(AtomViewHostMsg_Message, OnRendererMessage)


### PR DESCRIPTION
fix #388