### PR TITLE
remove restrictions on when DisableHardwardAcceleration can be called…

### DIFF
--- a/atom/browser/api/atom_api_app.cc
+++ b/atom/browser/api/atom_api_app.cc
@@ -778,11 +778,6 @@ bool App::Relaunch(mate::Arguments* js_args) {
 }
 
 void App::DisableHardwareAcceleration(mate::Arguments* args) {
-  if (atom::Browser::Get()->is_ready()) {
-    args->ThrowError("app.disableHardwareAcceleration() can only be called "
-                     "before app is ready");
-    return;
-  }
   content::GpuDataManager::GetInstance()->DisableHardwareAcceleration();
 }
 


### PR DESCRIPTION
…. Verified in chrome://gpu that gpu process was still disabled when called after app.on(‘ready’)