### PR TITLE
Using net::ERR_ABORTED instead of net::ERR_BLOCKED_BY_CLIENT which will

### DIFF
--- a/atom/browser/net/atom_network_delegate.cc
+++ b/atom/browser/net/atom_network_delegate.cc
@@ -489,7 +489,7 @@ void AtomNetworkDelegate::OnListenerResultInIO(
 
   bool cancel = false;
   response->GetBoolean("cancel", &cancel);
-  callbacks_[id].Run(cancel ? net::ERR_BLOCKED_BY_CLIENT : net::OK);
+  callbacks_[id].Run(cancel ? net::ERR_ABORTED : net::OK);
 }
 
 template<typename T>


### PR DESCRIPTION
block the following request after first blocked request

fix https://github.com/brave/browser-laptop/issues/12233

Auditors: @bridiver, @bbondy, @bsclifton