### PR TITLE
Don't get read only shared memory handle when the handle of read_only…

### DIFF
--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -2253,7 +2253,7 @@ bool WebContents::SendIPCSharedMemory(int render_process_id,
                                       const base::string16& channel,
                                       base::SharedMemory* shared_memory) {
   base::SharedMemoryHandle memory_handle =
-      shared_memory->GetReadOnlyHandle().Duplicate();
+      shared_memory->handle().Duplicate();
 
   auto rfh =
       content::RenderFrameHost::FromID(render_process_id, render_frame_id);


### PR DESCRIPTION
…_shm_ is -1

Auditors: @bridiver, @bbondy, @bsclifton

fix https://github.com/brave/browser-laptop/issues/12298

```
Check failed: readonly_shm_.IsValid().
#0 0x000002ed77ac base::debug::StackTrace::StackTrace()
#1 0x000002eee9fc logging::LogMessage::~LogMessage()
#2 0x000002ef141a base::SharedMemory::GetReadOnlyHandle()
#3 0x000002c87069 atom::api::WebContents::SendIPCSharedMemory()
#4 0x000002c934b6 mate::internal::Dispatcher<>::DispatchToCallback()
#5 0x00000185de69 v8::internal::FunctionCallbackArguments::Call()
#6 0x0000018ead11 v8::internal::(anonymous namespace)::HandleApiCallHelper<>()
#7 0x0000018ea312 v8::internal::Builtin_Impl_HandleApiCall()
#8 0x35cc5628469d <unknown>
```