### PR TITLE
only check origin for remote webframes - https://crbug.com/628759

### DIFF
--- a/atom/renderer/content_settings_manager.cc
+++ b/atom/renderer/content_settings_manager.cc
@@ -11,6 +11,8 @@
 #include "components/content_settings/core/common/content_settings_pattern.h"
 #include "content/public/common/url_constants.h"
 #include "content/public/renderer/render_thread.h"
+#include "third_party/WebKit/public/web/WebDocument.h"
+#include "third_party/WebKit/public/web/WebLocalFrame.h"
 #include "url/gurl.h"
 #include "url/url_constants.h"
 
@@ -30,6 +32,19 @@ ContentSettingsManager* ContentSettingsManager::GetInstance() {
   static base::LazyInstance<ContentSettingsManager>::DestructorAtExit manager =
     LAZY_INSTANCE_INITIALIZER;
   return manager.Pointer();
+}
+
+//  static
+GURL ContentSettingsManager::GetOriginOrURL(const blink::WebFrame* frame) {
+  url::Origin top_origin = url::Origin(frame->Top()->GetSecurityOrigin());
+  // The |top_origin| is unique ("null") e.g., for file:// URLs. Use the
+  // document URL as the primary URL in those cases.
+  // TODO(alexmos): This is broken for --site-per-process, since top() can be a
+  // WebRemoteFrame which does not have a document(), and the WebRemoteFrame's
+  // URL is not replicated.  See https://crbug.com/628759.
+  if (top_origin.unique() && frame->Top()->IsWebLocalFrame())
+    return frame->Top()->ToWebLocalFrame()->GetDocument().Url();
+  return top_origin.GetURL();
 }
 
 bool ContentSettingsManager::OnControlMessageReceived(

--- a/atom/renderer/content_settings_manager.h
+++ b/atom/renderer/content_settings_manager.h
@@ -21,6 +21,10 @@ namespace base {
 class DictionaryValue;
 }
 
+namespace blink {
+class WebFrame;
+}
+
 namespace atom {
 
 class ContentSettingsManager : public content::RenderThreadObserver {
@@ -29,6 +33,7 @@ class ContentSettingsManager : public content::RenderThreadObserver {
   ~ContentSettingsManager() override;
 
   static ContentSettingsManager* GetInstance();
+  static GURL GetOriginOrURL(const blink::WebFrame* frame);
 
   const base::DictionaryValue* content_settings() const
     { return content_settings_.get(); };

--- a/brave/renderer/extensions/content_settings_bindings.cc
+++ b/brave/renderer/extensions/content_settings_bindings.cc
@@ -17,6 +17,8 @@
 #include "third_party/WebKit/public/web/WebLocalFrame.h"
 #include "third_party/WebKit/public/web/WebDocument.h"
 
+using atom::ContentSettingsManager;
+
 namespace mate {
 
 template<>
@@ -61,17 +63,13 @@ void ContentSettingsBindings::GetCurrentSetting(
       mate::V8ToString(args[0].As<v8::String>());
   bool incognito = args[1].As<v8::Boolean>()->Value();
 
-  auto render_view = context()->GetRenderFrame()->GetRenderView();
-  GURL main_frame_url = render_view
-      ->GetWebView()->MainFrame()->ToWebLocalFrame()->GetDocument().Url();
-
   ContentSetting setting =
     atom::ContentSettingsManager::GetInstance()->GetSetting(
-          main_frame_url,
+          ContentSettingsManager::GetOriginOrURL(
+              context()->GetRenderFrame()->GetWebFrame()),
           context()->web_frame()->GetDocument().Url(),
           content_type,
           incognito);
-
 
   args.GetReturnValue().Set(
     mate::Converter<ContentSetting>::ToV8(context()->isolate(), setting));


### PR DESCRIPTION
fixes crash for content settings when site isolation is enabled