### PR TITLE
Do not prompt users to save password on passphrase confirmation page

### DIFF
--- a/brave/browser/password_manager/brave_password_manager_client.h
+++ b/brave/browser/password_manager/brave_password_manager_client.h
@@ -151,6 +151,8 @@ class BravePasswordManagerClient
       content::WebContents* contents,
       autofill::AutofillClient* autofill_client);
 
+  static bool IsPossibleConfirmPasswordForm(const autofill::PasswordForm& form);
+
   // Observer for PasswordGenerationPopup events. Used for testing.
   void SetTestObserver(autofill::PasswordGenerationPopupObserver* observer);
 


### PR DESCRIPTION
fix https://github.com/brave/browser-laptop/issues/12563

Auditors: @bridiver, @diracdeltas

Test plan:
a.
1. Make sure built-in password manager is enabled
2. Male sure passphrase is set on trezor wallet
3. Plugin trezor and open wallet
4. Type passphrase and submit
5. Brave shouldn't prompt any messages to save password

b.
1. Make sure built-in password manager is enabled
2. Sign up account for https://trac.torproject.org
3. Brave should ask users to save password, click deny
4. Logout and Login
5. Brave should ask users to save password, click allow
6. Change password
7. Brave should ask users to update password, click allow
8. Logout and use the save credentials to login
9. It should be able to login sucessfully
  