### PR TITLE
[WIP] chrome.contextMenus.remove

### DIFF
--- a/atom/common/api/resources/context_menus_bindings.js
+++ b/atom/common/api/resources/context_menus_bindings.js
@@ -23,10 +23,29 @@ var binding = {
       // ipc.off('chrome-context-menus-clicked', cb)
     }
   },
+  remove: function (menuItemId, cb) {
+    switch(typeof menuItemId) {
+        case 'number':
+        case 'string':
+            break; // accepted cases
+        default:
+            throw new Error('Please define the desired context menu to remove by its number or string identifier.')
+    }
+
+    var responseId = createResponseId()
+    ipc.once('chrome-context-menus-remove-response-' + responseId, function(evt) {
+      if (cb) {
+        cb()
+      }
+    })
+    ipc.send('chrome-context-menus-remove', responseId, extensionId, menuItemId)
+  },
   removeAll: function (cb) {
     var responseId = createResponseId()
-    cb && ipc.once('chrome-context-menus-remove-all-response-' + responseId, function(evt) {
-      cb()
+    ipc.once('chrome-context-menus-remove-all-response-' + responseId, function(evt) {
+      if (cb) {
+        cb()
+      }
     })
     ipc.send('chrome-context-menus-remove-all', responseId, extensionId)
   },
@@ -45,8 +64,10 @@ var binding = {
     if (properties.enabled !== undefined) {
       throw new Error('createProperties.enabled of contextMenus.create is not supported yet')
     }
-    cb && ipc.once('chrome-context-menus-create-response-' + responseId, function(evt) {
-      cb()
+    ipc.once('chrome-context-menus-create-response-' + responseId, function(evt) {
+      if (cb) {
+        cb()
+      }
     })
     properties.onclick && ipc.on('chrome-context-menus-clicked', (evt, info, tab) => {
       if (info.menuItemId === menuItemId) {

--- a/atom/common/api/resources/context_menus_bindings.js
+++ b/atom/common/api/resources/context_menus_bindings.js
@@ -79,6 +79,48 @@ var binding = {
     ipc.send('chrome-context-menus-create', responseId, extensionId, menuItemId, properties, icon)
     return menuItemId
   }
+  update: function (menuItemId, properties, cb) {
+    switch(typeof menuItemId) {
+        case 'number':
+        case 'string':
+            break; // accepted cases
+        default:
+            throw new Error('Please define the desired context menu to remove by its number or string identifier.')
+    }
+
+    if (!properties) {
+        if (cb) {
+            cb();
+        }
+        return
+    }
+
+    var responseId = createResponseId()
+    if (properties.checked !== undefined) {
+      throw new Error('createProperties.checked of contextMenus.update is not supported yet')
+    }
+    if (properties.documentUrlPatterns !== undefined) {
+      throw new Error('createProperties.documentUrlPatterns of contextMenus.update is not supported yet')
+    }
+    if (properties.targetUrlPatterns !== undefined) {
+      throw new Error('createProperties.targetUrlPatterns of contextMenus.update is not supported yet')
+    }
+    if (properties.enabled !== undefined) {
+      throw new Error('createProperties.enabled of contextMenus.update is not supported yet')
+    }
+    ipc.once('chrome-context-menus-update-response-' + responseId, function(evt) {
+      if (cb) {
+        cb()
+      }
+    })
+    ipc.on('chrome-context-menus-update', (evt, info, tab) => {
+      if (properties.onclick && info.menuItemId === menuItemId) {
+        properties.onclick(info, tab)
+      }
+    })
+    let manifest = runtime.getManifest()
+    ipc.send('chrome-context-menus-update', responseId, extensionId, menuItemId, properties)
+  }
 }
 
 exports.binding = binding

--- a/lib/browser/api/extensions.js
+++ b/lib/browser/api/extensions.js
@@ -801,6 +801,11 @@ ipcMain.on('chrome-context-menus-create', function (evt, responseId, extensionId
   evt.sender.send('chrome-context-menus-create-response-' + responseId)
 })
 
+ipcMain.on('chrome-context-menus-update', function(evt, responseId, extensionId, menuItemId, properties) {
+    process.emit('chrome-context-menus-update', extensionId, menuItemId, properties)
+    evt.sender.send('chrome-context-menus-update-response-' + responseId)
+})
+
 process.on('chrome-context-menus-clicked', function (extensionId, tabId, info) {
   let response = getTabValue(tabId)
   if (response) {

--- a/lib/browser/api/extensions.js
+++ b/lib/browser/api/extensions.js
@@ -786,6 +786,11 @@ ipcMain.on('autofill-popup-hidden', function (evt, tabId) {
     tab.autofillPopupHidden()
 })
 
+ipcMain.on('chrome-context-menus-remove', function(evt, responseId, extensionId, menuItemId) {
+    process.emit('chrome-context-menus-remove', extensionId, menuItemId)
+    evt.sender.send('chrome-context-menus-remove-response-' + responseId)
+})
+
 ipcMain.on('chrome-context-menus-remove-all', function (evt, responseId, extensionId) {
   process.emit('chrome-context-menus-remove-all', extensionId)
   evt.sender.send('chrome-context-menus-remove-all-response-' + responseId)


### PR DESCRIPTION
https://github.com/brave/browser-laptop/issues/8789

According to https://developer.chrome.com/extensions/contextMenus the callback functions ("cb") are optional, so we should still register the event, just not execute the callback if one is not provided.