### PR TITLE
Add guide for moving to Muon from Electron

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ into the browser process only for security reasons.
 
 It may be a better fit than [Electron](https://github.com/electron/electron) for your application, if your application
 needs to leverage the full support of Chromium, needs tighter security, or needs support for things like autofill and
-extensions.
+extensions. See the [Moving from Electron to Muon](docs/tutorials/moving-from-electron.md) guide to help make the transition.
 
 Some of Muons goals include:
 - use the Chromium source directly (eliminating electron's copy of `chrome_src`) with minor patches

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ into the browser process only for security reasons.
 
 It may be a better fit than [Electron](https://github.com/electron/electron) for your application, if your application
 needs to leverage the full support of Chromium, needs tighter security, or needs support for things like autofill and
-extensions. See the [Moving from Electron to Muon](docs/tutorials/moving-from-electron.md) guide to help make the transition.
+extensions. See the [Moving from Electron to Muon](docs/tutorial/moving-from-electron.md) guide to help make the transition.
 
 Some of Muons goals include:
 - use the Chromium source directly (eliminating electron's copy of `chrome_src`) with minor patches

--- a/docs/tutorial/moving-from-electron.md
+++ b/docs/tutorial/moving-from-electron.md
@@ -73,6 +73,24 @@ Brave uses the first solution in its [`'brave'` extension](https://github.com/br
 - Attributes which are no longer supported: `allowtransparency`, `httpreferer`
 - `getURL`, `send`, and other remote methods can only be called from the main process. Example in [#396](https://github.com/brave/muon/issues/396#issuecomment-358521847)
 
+### `preload` scripts
+
+Preload scripts have been removed in favor of [Chrome extension content scripts](https://developer.chrome.com/extensions/content_scripts). 
+
+The `ipcRenderer` API is still available under the `chrome.*` object in content scripts.
+
+#### Mimicking a preload script from a Chrome extension
+
+If mutating any `window.*` global object is important for your project, it can be closely mimicked by injecting a JavaScript file from your content script.
+
+```js
+const script = document.createElement('script');
+script.src = chrome.runtime.getURL('preload.js');
+document.documentElement.appendChild(script);
+```
+
+Set the [extension manifest](https://developer.chrome.com/extensions/content_scripts#registration)'s `run_at` property to use the value of `'document_start'` in combination with the above script to closely match the scope and timing of Electron's preload scripts.
+
 ## [`protocol`](../api/protocol.md) API
 
 - `protocol.registerFileProtocol` is removed

--- a/docs/tutorial/moving-from-electron.md
+++ b/docs/tutorial/moving-from-electron.md
@@ -105,6 +105,22 @@ Set the [extension manifest](https://developer.chrome.com/extensions/content_scr
 - `protocol.registerFileProtocol` is removed
 - `protocol.registerStreamProtocol` is not yet supported (brave/browser-laptop#10629)
 
+## WidevineCDM
+
+Muon supports downloading and using WidevineCDM binaries with the [`componentUpdater`](../api/component-updater.md) API.
+
+Add the following code to the main process for WidevineCDM support.
+```js
+const widevineComponentId = 'oimompecagnajdejgnnjijobebaeigek'
+const widevineComponentPublicKey = 'MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCmhe+02cLPPAViaevk/fzODKUnb/ysaAeD8lpE9pwirV6GYOm+naTo7xPOCh8ujcR6Ryi1nPTq2GTG0CyqdDyOsZ1aRLuMZ5QqX3dJ9jXklS0LqGfosoIpGexfwggbiLvQOo9Q+IWTrAO620KAzYU0U6MV272TJLSmZPUEFY6IGQIDAQAB'
+
+componentUpdater.on('component-registered', (event, componentId) => {
+  componentUpdater.checkNow(componentId)
+})
+
+componentUpdater.registerComponent(widevineComponentId, widevineComponentPublicKey)
+```
+
 ## Links
 
 - [browser-laptop](https://github.com/brave/browser-laptop) - Brave Browser built using Muon

--- a/docs/tutorial/moving-from-electron.md
+++ b/docs/tutorial/moving-from-electron.md
@@ -1,0 +1,88 @@
+# Moving from Electron to Muon
+
+Muon is a fork of Electron with improved security and support for Chrome extensions.
+
+While both provide similar features, it's important to note that Muon has mostly diverged from Electron changes since around Electron v1.4.13 (Dec 20, 2016) due to architectural differences [[1]](#ref1).
+
+This document details API differences which affect switching to Muon.
+
+As Muon is actively maintained for use in [Brave Browser](https://brave.com/), it can also be useful to study the code found in [brave/browser-laptop](https://github.com/brave/browser-laptop).
+
+## Prebuilt binaries
+
+Prebuilt binaries for Muon are provided by the [brave/electron-prebuilt](https://github.com/brave/electron-prebuilt) repo. It can be used in `package.json` along with related variables configured in `.npmrc`. Running `npm install && npm rebuild` after adding the following changes should switch your project to use Muon.
+
+`package.json`
+```json
+{
+	"devDependencies": {
+		"electron": "brave/electron-prebuild"
+	}
+}
+```
+
+`.npmrc`
+```
+runtime = electron
+target_arch = x64
+brave_electron_version = 4.7.2
+chromedriver_version = 2.33
+target = v4.7.2
+disturl=https://brave-laptop-binaries.s3.amazonaws.com/atom-shell/dist/
+build_from_source = true
+```
+
+See [`.npmrc` in brave/browser-laptop](https://github.com/brave/browser-laptop/blob/master/.npmrc) for up-to-date versions.
+
+## Process sandbox
+
+Muon removes NodeJS integration from the renderer process to improve security by enabling [Chromium's Sandbox features](https://chromium.googlesource.com/chromium/src/+/b4730a0c2773d8f6728946013eb812c6d3975bec/docs/design/sandbox.md).
+
+A limited subset of Electron APIs are still available when files are loaded using the `chrome://brave/*` protocol. The wildcard path accepts an absolute file path and works similar to the `file:///*` protocol.
+
+APIs are available under the `chrome.*` global object. Among those included are [`ipcRenderer`](docs/api/ipc-renderer.md), [`remote`](docs/api/remote.md), and [`webFrame`](docs/api/web-frame.md).
+
+### Webpack configuration
+
+Using webpack's [`externals`](https://webpack.js.org/configuration/externals/) config can provide an easier transition instead of replacing all `'electron'` imports.
+```js
+externals: {
+    'electron': 'chrome'
+}
+```
+
+## asar archives
+
+[Electron's asar archives](https://github.com/electron/asar) are deprecated in Muon and will be removed sometime in the future. They're planned to be replaced with pak files.
+
+Currently Brave uses them to archive extensions which are to be unpacked on first startup.
+
+### Removed `asar://` protocol
+
+As part of the deprecation of asar archives, it is unavailable as a browser protocol.
+
+Some alternatives for packaging app resources include:
+1. Package resources into a Chrome Extension.
+1. Include resources as flat files outside of an archive. Using `chrome://brave/*` can work as an alternate `file:///` in a renderer.
+
+Brave uses the first solution in its [`'brave'` extension](https://github.com/brave/browser-laptop/tree/master/app/extensions/brave).
+
+## `<webview>` element
+
+- Not available in renderers without `chrome://brave/*` prefix.
+- Attributes which are no longer supported: `allowtransparency`, `httpreferer`
+- `getURL`, `send`, and other remote methods can only be called from the main process. Example in [#396](https://github.com/brave/muon/issues/396#issuecomment-358521847)
+
+## [`protocol`](docs/api/protocol.md) API
+
+- `protocol.registerFileProtocol` is removed
+- `protocol.registerStreamProtocol` is not yet supported (brave/browser-laptop#10629)
+
+## Links
+
+- [browser-laptop](https://github.com/brave/browser-laptop) - Brave Browser built using Muon
+- [muon-quick](https://github.com/brave/muon-quick) - Sample code to get started with Muon; analagous to [electron-quick-start](https://github.com/electron/electron-quick-start).
+
+## References
+
+<a name="ref1">[1]</a> "I think we mainly split on a philosophical difference. Electron pulled in a minimal amount of chromium code and built custom apis on top of it. We have been moving in the other direction pulling in more chromium code and exposing js apis for it" - [@bridiver](https://github.com/bridiver)

--- a/docs/tutorial/moving-from-electron.md
+++ b/docs/tutorial/moving-from-electron.md
@@ -79,16 +79,16 @@ The resolved url would resemble `chrome://brave//Users/Foobar/MyApp/app/assets/i
 ## `<webview>` element
 
 - Not available in renderers without `chrome://brave/*` prefix.
-- Attributes which are no longer supported: `allowtransparency`, `httpreferer`
+- Attributes which are no longer supported: `preload`, `allowtransparency`, `httpreferer`
 - `getURL`, `send`, and other remote methods can only be called from the main process. Example in [#396](https://github.com/brave/muon/issues/396#issuecomment-358521847)
 
-### `preload` scripts
+## `preload` scripts
 
 Preload scripts have been removed in favor of [Chrome extension content scripts](https://developer.chrome.com/extensions/content_scripts). 
 
 The `ipcRenderer` API is still available under the `chrome.*` object in content scripts.
 
-#### Mimicking a preload script from a Chrome extension
+### Mimicking a preload script from a Chrome extension
 
 If mutating any `window.*` global object is important for your project, it can be closely mimicked by injecting a JavaScript file from your content script.
 
@@ -103,7 +103,7 @@ Set the [extension manifest](https://developer.chrome.com/extensions/content_scr
 ## [`protocol`](../api/protocol.md) API
 
 - `protocol.registerFileProtocol` is removed
-- `protocol.registerStreamProtocol` is not yet supported (brave/browser-laptop#10629)
+- `protocol.registerStreamProtocol` is not yet supported ([brave/browser-laptop#10629](https://github.com/brave/browser-laptop/issues/10629))
 
 ## WidevineCDM
 

--- a/docs/tutorial/moving-from-electron.md
+++ b/docs/tutorial/moving-from-electron.md
@@ -34,6 +34,10 @@ build_from_source = true
 
 See [`.npmrc` in brave/browser-laptop](https://github.com/brave/browser-laptop/blob/master/.npmrc) for up-to-date versions.
 
+### Building from source
+
+Refer to the [browser-laptop-bootstrap](https://github.com/brave/browser-laptop-bootstrap) repo for instructions on building Muon from source.
+
 ## Process sandbox
 
 Muon removes NodeJS integration from the renderer process to improve security by enabling [Chromium's Sandbox features](https://chromium.googlesource.com/chromium/src/+/b4730a0c2773d8f6728946013eb812c6d3975bec/docs/design/sandbox.md).

--- a/docs/tutorial/moving-from-electron.md
+++ b/docs/tutorial/moving-from-electron.md
@@ -40,7 +40,7 @@ Muon removes NodeJS integration from the renderer process to improve security by
 
 A limited subset of Electron APIs are still available when files are loaded using the `chrome://brave/*` protocol. The wildcard path accepts an absolute file path and works similar to the `file:///*` protocol.
 
-APIs are available under the `chrome.*` global object. Among those included are [`ipcRenderer`](docs/api/ipc-renderer.md), [`remote`](docs/api/remote.md), and [`webFrame`](docs/api/web-frame.md).
+APIs are available under the `chrome.*` global object. Among those included are [`ipcRenderer`](../api/ipc-renderer.md), [`remote`](../api/remote.md), and [`webFrame`](../api/web-frame.md).
 
 ### Webpack configuration
 
@@ -73,7 +73,7 @@ Brave uses the first solution in its [`'brave'` extension](https://github.com/br
 - Attributes which are no longer supported: `allowtransparency`, `httpreferer`
 - `getURL`, `send`, and other remote methods can only be called from the main process. Example in [#396](https://github.com/brave/muon/issues/396#issuecomment-358521847)
 
-## [`protocol`](docs/api/protocol.md) API
+## [`protocol`](../api/protocol.md) API
 
 - `protocol.registerFileProtocol` is removed
 - `protocol.registerStreamProtocol` is not yet supported (brave/browser-laptop#10629)

--- a/docs/tutorial/moving-from-electron.md
+++ b/docs/tutorial/moving-from-electron.md
@@ -16,7 +16,7 @@ Prebuilt binaries for Muon are provided by the [brave/electron-prebuilt](https:/
 ```json
 {
 	"devDependencies": {
-		"electron": "brave/electron-prebuild"
+		"electron": "brave/electron-prebuilt"
 	}
 }
 ```

--- a/docs/tutorial/moving-from-electron.md
+++ b/docs/tutorial/moving-from-electron.md
@@ -59,13 +59,22 @@ Currently Brave uses them to archive extensions which are to be unpacked on firs
 
 ### Removed `asar://` protocol
 
-As part of the deprecation of asar archives, it is unavailable as a browser protocol.
+Accessing contents of an asar archive is no longer possible using the `asar://` protocol. In its place is the `chrome://brave/` protocol which supports loading files from within `.asar` archives.
 
-Some alternatives for packaging app resources include:
-1. Package resources into a Chrome Extension.
-1. Include resources as flat files outside of an archive. Using `chrome://brave/*` can work as an alternate `file:///` in a renderer.
+In the renderer context, the `__dirname` global is unavailable due to removed NodeJS integration. To link to files within the asar archive, use paths relative to your app's entry html file—similar to a typical web application.
 
-Brave uses the first solution in its [`'brave'` extension](https://github.com/brave/browser-laptop/tree/master/app/extensions/brave).
+Given an application structure of
+```
+app/
+  assets/icon.svg
+  index.html
+```
+
+Using `icon.svg` can be linked using a relative path.
+```html
+<img src="./assets/icon.svg" />
+```
+The resolved url would resemble `chrome://brave//Users/Foobar/MyApp/app/assets/icon.svg`. Keep in mind, the window frame's location must be using the `chrome://brave/` protocol for this to work.
 
 ## `<webview>` element
 


### PR DESCRIPTION
I'm currently in the process of moving an app from Electron to Muon which has led me to a number of surprises. Along the way I've documented what I've found in hopes of making it easier for other developers.

[Here's a preview of the guide so far.](https://github.com/samuelmaddock/muon/blob/electron-guide/docs/tutorial/moving-from-electron.md) Let me know what you think!

It would also be useful to merge #417 to complement this guide.