### PR TITLE
run setProxy callback

### DIFF
--- a/atom/browser/api/atom_api_session.cc
+++ b/atom/browser/api/atom_api_session.cc
@@ -302,7 +302,7 @@ void SetProxyInIO(scoped_refptr<net::URLRequestContextGetter> getter,
   // Refetches and applies the new pac script if provided.
   proxy_service->ForceReloadProxyConfig();
   BrowserThread::PostTask(
-      BrowserThread::UI, FROM_HERE, base::Bind(&base::DoNothing));
+      BrowserThread::UI, FROM_HERE, callback);
 }
 
 void SetCertVerifyProcInIO(


### PR DESCRIPTION
needed for https://github.com/brave/browser-laptop/pull/12987 (it uses ses.setProxy to check whether a Tor process is running before Tor Tabs can be enabled)