### PR TITLE
Downloaded files on macOS should be quarantined by default

### DIFF
--- a/app/mac/resources/app-Info.plist
+++ b/app/mac/resources/app-Info.plist
@@ -34,5 +34,7 @@
   <true/>
   <key>NSHighResolutionCapable</key>
   <true/>
+  <key>LSFileQuarantineEnabled</key>
+  <true/>
 </dict>
 </plist>

--- a/app/mac/resources/helper-Info.plist
+++ b/app/mac/resources/helper-Info.plist
@@ -18,5 +18,7 @@
   <true/>
   <key>NSSupportsAutomaticGraphicsSwitching</key>
   <true/>
+  <key>LSFileQuarantineEnabled</key>
+  <true/>
 </dict>
 </plist>


### PR DESCRIPTION
https://hackerone.com/bugs?report_id=313440

Test:
- Open - https://nodejs.org/dist/v8.9.4/node-v8.9.4.pkg
- Run -

> $ xattr ~/Downloads/node-v8.9.4.pkg
> com.apple.metadata:kMDItemWhereFroms
> com.apple.quarantine
> 

Quarantine flag should be enabled for the file

fix https://github.com/brave/browser-laptop/issues/13088