### PR TITLE
Hide title bar bg on Mac for non-normal styles.

### DIFF
--- a/atom/browser/native_window_mac.mm
+++ b/atom/browser/native_window_mac.mm
@@ -664,10 +664,16 @@ NativeWindowMac::NativeWindowMac(
   // We will manage window's lifetime ourselves.
   [window_ setReleasedWhenClosed:NO];
 
+  // Hide the title bar background
+  if (title_bar_style_ != NORMAL) {
+    if (base::mac::IsAtLeastOS10_10()) {
+      [window_ setTitlebarAppearsTransparent:YES];
+    }
+  }
+
   // Hide the title bar.
   if (title_bar_style_ == HIDDEN_INSET) {
     if (base::mac::IsAtLeastOS10_10()) {
-      [window_ setTitlebarAppearsTransparent:YES];
       base::scoped_nsobject<NSToolbar> toolbar(
           [[NSToolbar alloc] initWithIdentifier:@"titlebarStylingToolbar"]);
       [toolbar setShowsBaselineSeparator:NO];


### PR DESCRIPTION
Fix #445 
This is a simple copy/paste of a fix in Electron:
https://github.com/electron/electron/pull/11164/files