### PR TITLE
Obtain extension from path when no mime type available

### DIFF
--- a/atom/browser/atom_download_manager_delegate.cc
+++ b/atom/browser/atom_download_manager_delegate.cc
@@ -139,7 +139,12 @@ void AtomDownloadManagerDelegate::OnDownloadPathGenerated(
   if (path.empty()) {
     std::vector<base::FilePath::StringType> extensions;
     base::FilePath::StringType extension;
-    if (GetItemExtension(item, &extension)) {
+    if (!GetItemExtension(item, &extension)) {
+      extension = target_path.Extension();
+      if (!extension.empty())
+        extension.erase(extension.begin());  // Erase preceding '.'.
+    }
+    if (!extension.empty()) {
       extensions.push_back(extension);
       file_type_info.extensions.push_back(extensions);
     }


### PR DESCRIPTION
fix https://github.com/brave/browser-laptop/issues/13230
fix https://github.com/brave/browser-laptop/issues/13228

Auditors: @bridiver, @bsclifton