### PR TITLE
Allow preventing HTML5 fullscreen api from resizing window

### DIFF
--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -1045,6 +1045,8 @@ void WebContents::OnEnterFullscreenModeForTab(content::WebContents* source,
                                               bool allowed) {
   if (!allowed)
     return;
+  bool prevent_default = Emit("will-enter-html-full-screen");
+  CommonWebContentsDelegate::SetHtmlApiFullscreenable(!prevent_default);
   CommonWebContentsDelegate::EnterFullscreenModeForTab(source, origin);
   Emit("enter-html-full-screen");
 }

--- a/atom/browser/common_web_contents_delegate.cc
+++ b/atom/browser/common_web_contents_delegate.cc
@@ -173,6 +173,7 @@ bool IsDevToolsFileSystemAdded(
 CommonWebContentsDelegate::CommonWebContentsDelegate()
     : html_fullscreen_(false),
       native_fullscreen_(false),
+      html_fullscreenable_(true),
       devtools_file_system_indexer_(new DevToolsFileSystemIndexer),
       weak_ptr_factory_(this) {
 }
@@ -620,7 +621,10 @@ void CommonWebContentsDelegate::SetHtmlApiFullscreen(bool enter_fullscreen) {
       return;
     }
 
-    owner_window_->SetFullScreen(enter_fullscreen);
+    // Set fullscreen on window if allowed.
+    if (html_fullscreenable_) {
+      owner_window_->SetFullScreen(enter_fullscreen);
+    }
   }
   html_fullscreen_ = enter_fullscreen;
   native_fullscreen_ = false;

--- a/atom/browser/common_web_contents_delegate.h
+++ b/atom/browser/common_web_contents_delegate.h
@@ -48,6 +48,9 @@ class CommonWebContentsDelegate
   // Returns the WebContents of devtools.
   content::WebContents* GetDevToolsWebContents() const;
 
+  // Set whether window is fullscreenable by HTML5 api.
+  // If disabled, the window will not resize when the HTML5
+  // fullscreen api is triggered.
   void SetHtmlApiFullscreenable(bool html_fullscreenable) {
     html_fullscreenable_ = html_fullscreenable;
   }

--- a/atom/browser/common_web_contents_delegate.h
+++ b/atom/browser/common_web_contents_delegate.h
@@ -48,6 +48,10 @@ class CommonWebContentsDelegate
   // Returns the WebContents of devtools.
   content::WebContents* GetDevToolsWebContents() const;
 
+  void SetHtmlApiFullscreenable(bool html_fullscreenable) {
+    html_fullscreenable_ = html_fullscreenable;
+  }
+
   virtual brightray::InspectableWebContents* managed_web_contents() const {
     return web_contents_.get();
   }
@@ -152,6 +156,9 @@ class CommonWebContentsDelegate
 
   // Whether window is fullscreened by window api.
   bool native_fullscreen_;
+
+  // Whether window is fullscreenable by HTML5 api.
+  bool html_fullscreenable_;
 
   scoped_refptr<DevToolsFileSystemIndexer> devtools_file_system_indexer_;
 


### PR DESCRIPTION
This introduces the ability to prevent the HTML5 fullscreen api from actually fullscreening the browser window. Calling `event.preventDefault()` in response to the `'will-enter-html-full-screen'` event will cause the html element to only take up the space of the browser window.

I'm adding this with the intention of fullscreening media within the browser window, but not changing its size.

## Example

#### main.js
```js
const { app, BrowserWindow } = require('electron')

app.on('web-contents-created', (event, webContents) => {
  webContents.on('will-enter-html-full-screen', event => {
    event.preventDefault()
  })
})

app.once('ready', () => {
  const win = new BrowserWindow({
    show: true,
    width: 800,
    height: 600
  })
  win.loadURL('https://www.youtube.com/watch?v=1Cs0qyG78qY')
})
```
![2018-02-28_22-24-25](https://user-images.githubusercontent.com/1656324/36825575-4028f114-1cd6-11e8-83cf-af5564a97729.gif)
