### PR TITLE
Make AtomNetworkdelegate::OnCompleted() cleanup internal data directly

### DIFF
--- a/atom/browser/net/atom_network_delegate.cc
+++ b/atom/browser/net/atom_network_delegate.cc
@@ -395,7 +395,7 @@ void AtomNetworkDelegate::OnCompleted(net::URLRequest* request,
                                       bool started,
                                       int net_error) {
   // OnCompleted may happen before other events.
-  OnURLRequestDestroyed(request);
+  callbacks_.erase(request->identifier());
 
   if (net_error != net::OK) {
     OnErrorOccurred(request, started, net_error);


### PR DESCRIPTION
AtomNetworkdelegate::OnURLRequestDestroyed() shouldn't be called in AtomNetworkdelegate::OnCompleted(). It causes calling AtomExtensionsNetworkDelegate::OnURLRequestDestroyed().
Before brave/muon@fb67093, OnCompleted() just cleanup internal data structure not by calling OnURLRequestDestroyed(). OnURLRequestDestroyed() only should be called by NetworkDelegate::NotifyURLRequestDestroyed().