### PR TITLE
 Emit 'did-get-response-details' from WebContents::DidFinishNavigation()

### DIFF
--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -1389,9 +1389,18 @@ void WebContents::DidFinishNavigation(
     content::NavigationHandle* navigation_handle) {
   Emit("did-finish-navigation", navigation_handle);
 
-  // deprecated event handling
   bool is_main_frame = navigation_handle->IsInMainFrame();
   auto url = navigation_handle->GetURL();
+
+  Emit("did-get-response-details",
+       navigation_handle->GetSocketAddress().IsEmpty(), url,
+       navigation_handle->GetPreviousURL(),
+       navigation_handle->GetResponseHeaders()->response_code(),
+       navigation_handle->IsPost() ? "POST" : "GET",
+       navigation_handle->GetReferrer().url,
+       is_main_frame ? "mainFrame" : "subFrame");
+
+  // deprecated event handling
   if (navigation_handle->HasCommitted() && !navigation_handle->IsErrorPage()) {
     bool is_in_page = navigation_handle->IsSameDocument();
     bool is_renderer_initiated = navigation_handle->IsRendererInitiated();

--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -1392,12 +1392,14 @@ void WebContents::DidFinishNavigation(
   bool is_main_frame = navigation_handle->IsInMainFrame();
   auto url = navigation_handle->GetURL();
 
+  const net::HttpResponseHeaders* headers = navigation_handle->GetResponseHeaders();
   Emit("did-get-response-details",
        navigation_handle->GetSocketAddress().IsEmpty(), url,
        navigation_handle->GetPreviousURL(),
-       navigation_handle->GetResponseHeaders()->response_code(),
+       headers ? headers->response_code() : 0,
        navigation_handle->IsPost() ? "POST" : "GET",
        navigation_handle->GetReferrer().url,
+       headers,
        is_main_frame ? "mainFrame" : "subFrame");
 
   // deprecated event handling


### PR DESCRIPTION
DidGetResourceResponseStart() was removed in
00d729f
as per https://crbug.com/783981. In the bug report,
DidFinishNavigation() is mentioned as a substitute.