### PR TITLE
Pass socks port, data directory to tor subprocess

### DIFF
--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -422,6 +422,10 @@ mate::Handle<api::Session> SessionFromOptions(v8::Isolate* isolate,
     if (options.Get("tor_path", &tor_path)) {
       session_options.SetString("tor_path", tor_path);
     }
+    std::string tor_data_dir;
+    if (options.Get("tor_data_dir", &tor_data_dir)) {
+      session_options.SetString("tor_data_dir", tor_data_dir);
+    }
     session = Session::FromPartition(isolate, partition, session_options);
   } else {
     // Use the default session if not specified.

--- a/lib/browser/api/extensions.js
+++ b/lib/browser/api/extensions.js
@@ -228,7 +228,8 @@ const createTab = function (createProperties, cb) {
       parent_partition: createProperties.parent_partition,
       isolated_storage: createProperties.isolated_storage,
       tor_proxy: createProperties.tor_proxy,
-      tor_path: createProperties.tor_path
+      tor_path: createProperties.tor_path,
+      tor_data_dir: createProperties.tor_data_dir
     })
     // don't pass the partition info through
     delete createProperties.partition


### PR DESCRIPTION
THIS PR IS NOT ACTUALLY TO BE MERGED!  The same semantic changes are to be replayed on top of @darkdh's work to use a utility process rather than LaunchProcess.

Adds option `tor_data_dir` and adjusts parsing of option `tor_proxy`, and passes arguments down to the tor program so that tor will run in the right data directory and listen on the right socks port and not pick up any torrc in /etc or whatever.

Addresses https://github.com/brave/muon/issues/530.