### PR TITLE
update community links

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,4 @@ Patch version changes are for everything else
 
 You can ask questions and interact with the community in the following
 locations:
-- [The Brave Community](https://community.brave.com/)
-- [`community`](https://bravesoftware.slack.com) channel on Brave Software's Slack
-- [`developers-muon`](https://discord.gg/k57tYrS) channel in our Brave Discord server
+- [The Brave Community](https://discord.gg/MdxcpKT) discord server.


### PR DESCRIPTION
As development will be switching from brave to the OSS platform, this PR handles the change of the discord server link for now as we get everything up to speed.