### PR TITLE
Fix NULL deref when deleting download prefs

### DIFF
--- a/atom/browser/atom_browser_context.cc
+++ b/atom/browser/atom_browser_context.cc
@@ -69,6 +69,9 @@ AtomBrowserContext::AtomBrowserContext(
 }
 
 AtomBrowserContext::~AtomBrowserContext() {
+  BrowserThread::DeleteSoon(BrowserThread::UI,
+                              FROM_HERE,
+                              download_manager_delegate_.release());
 }
 
 std::unique_ptr<net::URLRequestJobFactory>

--- a/atom/browser/atom_download_manager_delegate.cc
+++ b/atom/browser/atom_download_manager_delegate.cc
@@ -14,8 +14,10 @@
 #include "chrome/browser/browser_process.h"
 #include "chrome/browser/download/download_completion_blocker.h"
 #include "chrome/browser/download/download_item_model.h"
+#include "chrome/browser/download/download_prefs.h"
 #include "chrome/browser/extensions/api/file_system/file_entry_picker.h"
 #include "chrome/browser/profiles/profile.h"
+#include "chrome/browser/safe_browsing/download_protection/download_protection_util.h"
 #include "chrome/browser/safe_browsing/safe_browsing_service.h"
 #include "chrome/common/pref_names.h"
 #include "chrome/common/safe_browsing/file_type_policies.h"
@@ -258,6 +260,7 @@ AtomDownloadManagerDelegate::~AtomDownloadManagerDelegate() {
   if (download_manager_) {
     DCHECK_EQ(static_cast<content::DownloadManagerDelegate*>(this),
               download_manager_->GetDelegate());
+    download_prefs_.reset();
     download_manager_->SetDelegate(nullptr);
     download_manager_ = nullptr;
   }

--- a/atom/browser/atom_download_manager_delegate.h
+++ b/atom/browser/atom_download_manager_delegate.h
@@ -14,10 +14,8 @@
 #include "base/strings/utf_string_conversions.h"
 #include "base/task_scheduler/post_task.h"
 #include "chrome/browser/download/download_path_reservation_tracker.h"
-#include "chrome/browser/download/download_prefs.h"
 #include "chrome/browser/download/download_target_determiner.h"
 #include "chrome/browser/safe_browsing/download_protection/download_protection_service.h"
-#include "chrome/browser/safe_browsing/download_protection/download_protection_util.h"
 #include "content/public/browser/download_manager_delegate.h"
 
 class DownloadPrefs;


### PR DESCRIPTION
Fix: https://github.com/brave/muon/issues/558