### PR TITLE
Quarantine Downloads on MacOS + Unquarantine update bundle

### DIFF
--- a/app/mac/resources/app-Info.plist
+++ b/app/mac/resources/app-Info.plist
@@ -34,5 +34,7 @@
   <true/>
   <key>NSHighResolutionCapable</key>
   <true/>
+  <key>LSFileQuarantineEnabled</key>
+  <true/>
 </dict>
 </plist>

--- a/app/mac/resources/helper-Info.plist
+++ b/app/mac/resources/helper-Info.plist
@@ -18,5 +18,7 @@
   <true/>
   <key>NSSupportsAutomaticGraphicsSwitching</key>
   <true/>
+  <key>LSFileQuarantineEnabled</key>
+  <true/>
 </dict>
 </plist>

--- a/atom/browser/auto_updater_mac.mm
+++ b/atom/browser/auto_updater_mac.mm
@@ -8,6 +8,7 @@
 #import <ReactiveCocoa/RACSignal.h>
 #import <ReactiveCocoa/NSObject+RACPropertySubscribing.h>
 #import <Squirrel/Squirrel.h>
+#include <sys/xattr.h>
 
 #include "base/bind.h"
 #include "base/time/time.h"
@@ -90,6 +91,13 @@ void AutoUpdater::CheckForUpdates() {
       subscribeNext:^(SQRLDownloadedUpdate *downloadedUpdate) {
         if (downloadedUpdate) {
           g_update_available = true;
+          NSBundle *downloadBundle = downloadedUpdate.bundle;
+          NSString *bundlePath = [downloadBundle resourcePath];
+
+          NSRange appIndex = [bundlePath rangeOfString: @".app"];
+          NSString *appPath = [bundlePath substringWithRange: NSMakeRange (0, appIndex.location+4)];
+          removexattr([appPath UTF8String], "com.apple.quarantine", 0);
+
           SQRLUpdate* update = downloadedUpdate.update;
           // There is a new update that has been downloaded.
           delegate->OnUpdateDownloaded(


### PR DESCRIPTION
Repro steps:

Verify if quarantine works:

1. `npm run build` to build an official version of the app.
2. Run the development version and initiate a download
3. Verify the download has the quarantine attribute:
 ```
     > xattr <downloaded_file>
     > com.apple.quarantine
```

Build package and installer:

1. `rm -rf ~/.electron/*`
2. `cd src/browser-laptop && rm -rf node_modules`
3. `npm run create_dist`
4. `cp -r src/out/Release/dist/* ~/.electron/`
5. `cd src/browser-laptop && npm install`
6.  Verify if the correct Brave binary is copied to `electron-prebuilt`:
`unzip ~/.electron/brave-v5.1.2-darwin-x64.zip -d ~/.electron && shasum ~/.electron/Brave.app/Contents/MacOS/Brave`
`shasum node_modules/electron-prebuilt/dist/Brave.app/Contents/MacOS/Brave`
7. CHANNEL=dev npm run build-package
8. npm run build-installer (certs required)
9. Remove the current installation of Brave
10. Run: `BRAVE_ENABLE_PREVIEW_UPDATES=true /Applications/Brave.app/Contents/MacOS/Brave`
11. Check for updates and click on update.
12. On restart, confirm that the quarantine dialog box does not show up.
13. Verify the Brave binary or the package does not have the quarantine flag.
```
> xattr /Applications/Brave.app/
> xattr /Applications/Brave.app/Contents/MacOS/Brave
```