### PR TITLE
Updating missing deps for Socks5

### DIFF
--- a/patches/master_patch.patch
+++ b/patches/master_patch.patch
@@ -2109,6 +2109,23 @@ index b7fb84846acdd37de8593a1180dfaedd2fbc431c..3b4be3019ec0dd2fa0ed636bc6a56ea2
    return switches::autoplay::kUserGestureRequiredPolicy;
  #else
    return switches::autoplay::kNoUserGestureRequiredPolicy;
+diff --git a/net/BUILD.gn b/net/BUILD.gn
+index 7676ff4cbf84735a5d844983c8b857ad50cc3d06..0374344898e4580cefbc4b7a643bcc5c6a2d30bf 100644
+--- a/net/BUILD.gn
++++ b/net/BUILD.gn
+@@ -383,6 +383,12 @@ component("net") {
+ 
+   if (!is_nacl) {
+     sources += [
++      "//electron/chromium_src/net/socket/socks5_client_socket_auth.cc",
++      "//electron/chromium_src/net/socket/socks5_client_socket_auth.h",
++      "//electron/chromium_src/net/base/host_port_pair_auth.cc",
++      "//electron/chromium_src/net/base/host_port_pair_auth.h",
++      "//electron/chromium_src/net/base/url_auth_util.cc",
++      "//electron/chromium_src/net/base/url_auth_util.h",
+       "android/cellular_signal_strength.cc",
+       "android/cellular_signal_strength.h",
+       "android/cert_verify_result_android.cc",
 diff --git a/net/base/host_port_pair.cc b/net/base/host_port_pair.cc
 index ec8248449dbcd4156e361fcc8781ce0712f26a02..e9f4dce79a73c1949293c45486606377f4f11ebb 100644
 --- a/net/base/host_port_pair.cc


### PR DESCRIPTION
`npm run create_dist` was failing with

```
Undefined symbols for architecture x86_64:
  "net::SOCKS5ClientSocketAuth::SOCKS5ClientSocketAuth(std::__1::unique_ptr<net::ClientSocketHandle, std::__1::default_delete<net::ClientSocketHandle> >, net::HostResolver::RequestInfo const&, net::NetworkTrafficAnnotationTag const&, net::HostPortPair const&)", referenced from:
      net::SOCKSConnectJob::DoSOCKSConnect() in libnet.a(socks_client_socket_pool.o)
  "net::HostPortPair::ToString() const", referenced from:
      net::ProxyServer::ToURI() const in libnet.a(proxy_server.o)
      net::ProxyServer::ToPacString() const in libnet.a(proxy_server.o)
      net::TransportSecurityState::MaybeNotifyExpectCTFailed(net::HostPortPair const&, GURL const&, base::Time, net::X509Certificate const*, net::X509Certificate const*, std::__1::vector<net::SignedCertificateTimestampAndStatus, std::__1::allocator<net::SignedCertificateTimestampAndStatus> > const&) in libnet.a(transport_security_state.o)
      net::QuicServerId::ToString() const in libnet.a(quic_server_id.o)
      net::HostMappingRules::RewriteHost(net::HostPortPair*) const in libnet.a(host_mapping_rules.o)
      net::(anonymous namespace)::NetLogRequestInfoCallback(net::HostResolver::RequestInfo const*, net::NetLogCaptureMode) in libnet.a(host_resolver_impl.o)
      net::SSLClientSocketImpl::Init() in libnet.a(ssl_client_socket_impl.o)
      ...
  "net::ParseAuthHostAndPort(std::__1::__wrap_iter<char const*>, std::__1::__wrap_iter<char const*>, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >*, int*)", referenced from:
      net::ProxyServer::FromSchemeHostAndPort(net::ProxyServer::Scheme, std::__1::__wrap_iter<char const*>, std::__1::__wrap_iter<char const*>) in libnet.a(proxy_server.o)
  "net::HostPortPair::HostPortPair(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, unsigned short)", referenced from:
      net::ProxyServer::FromSchemeHostAndPort(net::ProxyServer::Scheme, std::__1::__wrap_iter<char const*>, std::__1::__wrap_iter<char const*>) in libnet.a(proxy_server.o)
      net::ProxyBypassRules::AddRuleFromStringInternal(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, bool) in libnet.a(proxy_bypass_rules.o)
      net::NetworkQualityEstimator::RequestProvidesRTTObservation(net::URLRequest const&) const in libnet.a(network_quality_estimator.o)
      net::HttpServerPropertiesImpl::UpdateCanonicalServerInfoMap(net::QuicServerId const&) in libnet.a(http_server_properties_impl.o)
      net::HttpServerPropertiesImpl::GetAlternativeServiceInfos(url::SchemeHostPort const&) in libnet.a(http_server_properties_impl.o)
      net::HttpServerPropertiesImpl::GetCanonicalServerInfoHost(net::QuicServerId const&) const in libnet.a(http_server_properties_impl.o)
      net::HostPortPair::FromURL(GURL const&) in libnet.a(host_port_pair.o)
      ...
ld: symbol(s) not found for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```

Updating deps to resolve this issue.