### PR TITLE
Update dependencies for Squirrel.Mac 0.3.2

### DIFF
--- a/script/update-external-binaries.py
+++ b/script/update-external-binaries.py
@@ -8,7 +8,7 @@ from lib.config import get_target_arch
 from lib.util import safe_mkdir, rm_rf, extract_zip, tempdir, download
 
 
-VERSION = 'v1.1.0'
+VERSION = 'v1.2.2'
 SOURCE_ROOT = os.path.abspath(os.path.dirname(os.path.dirname(__file__)))
 FRAMEWORKS_URL = 'http://github.com/electron/electron-frameworks/releases' \
                  '/download/' + VERSION


### PR DESCRIPTION
Potentially fixes https://github.com/brave/browser-laptop/issues/2184

electron-frameworks release 1.2.2 which includes Squirrel.Mac 0.3.2 that contains the fix in https://github.com/Squirrel/Squirrel.Mac/pull/207

This does not use the latest electron-frameworks release (1.3.0), which mentions another Squirrel.Mac update at https://github.com/electron/electron-frameworks/releases, as there is no corresponding Squirrel.Mac source / version info.