### PR TITLE
Fix renderer deps on linux

### DIFF
--- a/chromium_src/BUILD.gn
+++ b/chromium_src/BUILD.gn
@@ -349,6 +349,15 @@ source_set("browser") {
       "//chrome/browser/crash_upload_list/crash_upload_list_crashpad.cc",
       "//chrome/browser/crash_upload_list/crash_upload_list_crashpad.h",
     ]
+  } 
+
+  if (is_linux) {
+    sources += [
+      "chrome/browser/themes/theme_service.cc",
+      "//chrome/browser/themes/theme_service.h",
+      "chrome/browser/themes/theme_service_factory.cc",
+      "//chrome/browser/themes/theme_service_factory.h",
+     ]
   }
 
   if (is_win) {

--- a/chromium_src/BUILD.gn
+++ b/chromium_src/BUILD.gn
@@ -104,8 +104,6 @@ source_set("renderer") {
   configs += [ ":chromium_src_config" ]
 
   sources = [
-    "//chrome/browser/renderer_preferences_util.cc",
-    "//chrome/browser/renderer_preferences_util.h",
     "chrome/renderer/content_settings_observer.cc",
     "chrome/renderer/content_settings_observer.h",
   ]
@@ -254,6 +252,8 @@ source_set("browser") {
 
     "//chrome/browser/prefs/chrome_command_line_pref_store.cc",
     "//chrome/browser/prefs/chrome_command_line_pref_store.h",
+    "//chrome/browser/renderer_preferences_util.cc",
+    "//chrome/browser/renderer_preferences_util.h",
 
     "//chrome/browser/site_details.cc",
     "//chrome/browser/site_details.h",

--- a/chromium_src/chrome/browser/themes/theme_service.cc
+++ b/chromium_src/chrome/browser/themes/theme_service.cc
@@ -1,0 +1,127 @@
+#include "chrome/browser/themes/theme_service.h"
+
+#include "chrome/browser/themes/custom_theme_supplier.h"
+#include "chrome/browser/themes/theme_syncable_service.h"
+#include "chrome/browser/ui/libgtkui/skia_utils_gtk.h"
+#include "ui/base/resource/resource_bundle.h"
+#include "ui/gfx/color_utils.h"
+
+using ui::ResourceBundle;
+
+class ThemeService::ThemeObserver {
+};
+
+const char ThemeService::kDefaultThemeID[] = "";
+
+ThemeService::ThemeService()
+    : ready_(false),
+      rb_(ui::ResourceBundle::GetSharedInstance()),
+      profile_(nullptr),
+      installed_pending_load_id_(kDefaultThemeID),
+      number_of_infobars_(0),
+      original_theme_provider_(*this, false),
+      incognito_theme_provider_(*this, true),
+      weak_ptr_factory_(this) {}
+
+ThemeService::~ThemeService() {
+  DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
+  FreePlatformCaches();
+}
+
+void ThemeService::Init(Profile* profile) {
+}
+
+void ThemeService::Observe(int type,
+                           const content::NotificationSource& source,
+                           const content::NotificationDetails& details) {}
+
+void ThemeService::Shutdown() {}
+
+void ThemeService::UseDefaultTheme() {}
+
+void ThemeService::UseSystemTheme() {}
+
+bool ThemeService::IsSystemThemeDistinctFromDefaultTheme() const {
+  return false;
+}
+
+bool ThemeService::UsingDefaultTheme() const {
+  return false;
+}
+
+bool ThemeService::UsingSystemTheme() const {
+  return UsingDefaultTheme();
+}
+
+std::string ThemeService::GetThemeID() const {
+  return ThemeService::kDefaultThemeID;
+}
+
+ThemeSyncableService* ThemeService::GetThemeSyncableService() const {
+  return nullptr;
+}
+
+void ThemeService::SetCustomDefaultTheme(
+    scoped_refptr<CustomThemeSupplier> theme_supplier) {
+}
+
+bool ThemeService::ShouldInitWithSystemTheme() const {
+  return false;
+}
+
+SkColor ThemeService::GetDefaultColor(int id, bool incognito) const {
+  return SkColorSetARGB(255, 233, 233, 233);
+}
+
+void ThemeService::ClearAllThemeData() {}
+
+void ThemeService::LoadThemePrefs() {}
+
+void ThemeService::NotifyThemeChanged() {}
+
+void ThemeService::FreePlatformCaches() {}
+
+bool ThemeService::ShouldUseNativeFrame() const {
+  return false;
+}
+
+void ThemeService::DoSetTheme(const extensions::Extension* extension,
+                              bool suppress_infobar) {}
+
+ThemeService::BrowserThemeProvider::BrowserThemeProvider(
+    const ThemeService& theme_service,
+    bool incognito)
+    : theme_service_(theme_service), incognito_(incognito) {}
+
+ThemeService::BrowserThemeProvider::~BrowserThemeProvider() {}
+
+gfx::ImageSkia* ThemeService::BrowserThemeProvider::GetImageSkiaNamed(
+    int id) const {
+  return nullptr;
+}
+
+SkColor ThemeService::BrowserThemeProvider::GetColor(int id) const {
+  return SkColorSetARGB(255, 233, 233, 233);
+}
+
+color_utils::HSL ThemeService::BrowserThemeProvider::GetTint(int id) const {
+  return {0.0};
+}
+
+int ThemeService::BrowserThemeProvider::GetDisplayProperty(int id) const {
+  return 0;
+}
+
+bool ThemeService::BrowserThemeProvider::ShouldUseNativeFrame() const {
+  return false;
+}
+
+bool ThemeService::BrowserThemeProvider::HasCustomImage(int id) const {
+  return false;
+}
+
+base::RefCountedMemory* ThemeService::BrowserThemeProvider::GetRawData(
+    int id,
+    ui::ScaleFactor scale_factor) const {
+  return nullptr;
+}

--- a/chromium_src/chrome/browser/themes/theme_service.cc
+++ b/chromium_src/chrome/browser/themes/theme_service.cc
@@ -24,8 +24,6 @@ ThemeService::ThemeService()
       weak_ptr_factory_(this) {}
 
 ThemeService::~ThemeService() {
-  DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
-  FreePlatformCaches();
 }
 
 void ThemeService::Init(Profile* profile) {

--- a/chromium_src/chrome/browser/themes/theme_service_factory.cc
+++ b/chromium_src/chrome/browser/themes/theme_service_factory.cc
@@ -1,0 +1,18 @@
+#include "chrome/browser/themes/theme_service_factory.h"
+
+#include "base/logging.h"
+#include "build/build_config.h"
+#include "chrome/browser/profiles/incognito_helpers.h"
+#include "chrome/browser/profiles/profile.h"
+#include "chrome/browser/themes/theme_service.h"
+#include "chrome/common/pref_names.h"
+#include "components/keyed_service/content/browser_context_dependency_manager.h"
+#include "components/pref_registry/pref_registry_syncable.h"
+#include "components/prefs/pref_service.h"
+#include "extensions/browser/extension_registry.h"
+#include "extensions/browser/extension_registry_factory.h"
+
+// static
+ThemeService* ThemeServiceFactory::GetForProfile(Profile* profile) {
+  return new ThemeService;
+}

--- a/chromium_src/chrome/browser/themes/theme_service_factory.cc
+++ b/chromium_src/chrome/browser/themes/theme_service_factory.cc
@@ -1,18 +1,6 @@
 #include "chrome/browser/themes/theme_service_factory.h"
-
-#include "base/logging.h"
-#include "build/build_config.h"
-#include "chrome/browser/profiles/incognito_helpers.h"
-#include "chrome/browser/profiles/profile.h"
 #include "chrome/browser/themes/theme_service.h"
-#include "chrome/common/pref_names.h"
-#include "components/keyed_service/content/browser_context_dependency_manager.h"
-#include "components/pref_registry/pref_registry_syncable.h"
-#include "components/prefs/pref_service.h"
-#include "extensions/browser/extension_registry.h"
-#include "extensions/browser/extension_registry_factory.h"
 
-// static
 ThemeService* ThemeServiceFactory::GetForProfile(Profile* profile) {
   return new ThemeService;
 }

--- a/patches/master_patch.patch
+++ b/patches/master_patch.patch
@@ -433,33 +433,6 @@ index a5ea92f2878459b49f88d4895c7d18f2e157dd6c..9cffca0352713bce12b4035c02612cd7
      }
    }
  
-diff --git a/chrome/browser/renderer_preferences_util.cc b/chrome/browser/renderer_preferences_util.cc
-index ef8350dd1f99470c0e535f39ac48b8ff867d1105..200803d01a0ee6bce2d5b3b7d97ac735a96f6ef1 100644
---- a/chrome/browser/renderer_preferences_util.cc
-+++ b/chrome/browser/renderer_preferences_util.cc
-@@ -139,7 +139,9 @@ void UpdateFromSystemSettings(content::RendererPreferences* prefs,
- #if defined(USE_AURA) && defined(OS_LINUX) && !defined(OS_CHROMEOS)
-   views::LinuxUI* linux_ui = views::LinuxUI::instance();
-   if (linux_ui) {
-// Muon uses BuildGtkUi for LinuxUI so we don't need to check if we are using 
-// the System Theme but we want to preserve the attributes passed from GTK UI 
-// to Webkit
-+#if defined(MUON_CHROMIUM_BUILD)
-     if (ThemeServiceFactory::GetForProfile(profile)->UsingSystemTheme()) {
-+#endif
-       prefs->focus_ring_color = linux_ui->GetFocusRingColor();
-       prefs->thumb_active_color = linux_ui->GetThumbActiveColor();
-       prefs->thumb_inactive_color = linux_ui->GetThumbInactiveColor();
-@@ -150,7 +152,9 @@ void UpdateFromSystemSettings(content::RendererPreferences* prefs,
-         linux_ui->GetInactiveSelectionBgColor();
-       prefs->inactive_selection_fg_color =
-         linux_ui->GetInactiveSelectionFgColor();
-+#if defined(MUON_CHROMIUM_BUILD)
-     }
-+#endif
- 
-     // If we have a linux_ui object, set the caret blink interval regardless of
-     // whether we're in native theme mode.
 diff --git a/chrome/browser/resource_coordinator/tab_manager.cc b/chrome/browser/resource_coordinator/tab_manager.cc
 index 633dc40d895baee17ebe617c14cd4333fd044dad..59eb777fae2a1b1d69d097ffe0e7af126628d317 100644
 --- a/chrome/browser/resource_coordinator/tab_manager.cc

--- a/patches/master_patch.patch
+++ b/patches/master_patch.patch
@@ -433,6 +433,33 @@ index a5ea92f2878459b49f88d4895c7d18f2e157dd6c..9cffca0352713bce12b4035c02612cd7
      }
    }
  
+diff --git a/chrome/browser/renderer_preferences_util.cc b/chrome/browser/renderer_preferences_util.cc
+index ef8350dd1f99470c0e535f39ac48b8ff867d1105..200803d01a0ee6bce2d5b3b7d97ac735a96f6ef1 100644
+--- a/chrome/browser/renderer_preferences_util.cc
++++ b/chrome/browser/renderer_preferences_util.cc
+@@ -139,7 +139,9 @@ void UpdateFromSystemSettings(content::RendererPreferences* prefs,
+ #if defined(USE_AURA) && defined(OS_LINUX) && !defined(OS_CHROMEOS)
+   views::LinuxUI* linux_ui = views::LinuxUI::instance();
+   if (linux_ui) {
+// Muon uses BuildGtkUi for LinuxUI so we don't need to check if we are using 
+// the System Theme but we want to preserve the attributes passed from GTK UI 
+// to Webkit
++#if defined(MUON_CHROMIUM_BUILD)
+     if (ThemeServiceFactory::GetForProfile(profile)->UsingSystemTheme()) {
++#endif
+       prefs->focus_ring_color = linux_ui->GetFocusRingColor();
+       prefs->thumb_active_color = linux_ui->GetThumbActiveColor();
+       prefs->thumb_inactive_color = linux_ui->GetThumbInactiveColor();
+@@ -150,7 +152,9 @@ void UpdateFromSystemSettings(content::RendererPreferences* prefs,
+         linux_ui->GetInactiveSelectionBgColor();
+       prefs->inactive_selection_fg_color =
+         linux_ui->GetInactiveSelectionFgColor();
++#if defined(MUON_CHROMIUM_BUILD)
+     }
++#endif
+ 
+     // If we have a linux_ui object, set the caret blink interval regardless of
+     // whether we're in native theme mode.
 diff --git a/chrome/browser/resource_coordinator/tab_manager.cc b/chrome/browser/resource_coordinator/tab_manager.cc
 index 633dc40d895baee17ebe617c14cd4333fd044dad..59eb777fae2a1b1d69d097ffe0e7af126628d317 100644
 --- a/chrome/browser/resource_coordinator/tab_manager.cc


### PR DESCRIPTION
Fixes build failure on linux:

```
[11691/11692] LINK ./brave
FAILED: brave 
...
/src/src/out/Release/../../third_party/llvm-build/Release+Asserts/bin/ld.lld: error: undefined symbol: ThemeServiceFactory::GetForProfile(Profile*)
>>> referenced by renderer_preferences_util.cc:142 (../../chrome/browser/renderer_preferences_util.cc:142)
>>>               obj/electron/chromium_src/renderer/renderer_preferences_util.o:(renderer_preferences_util::UpdateFromSystemSettings(content::RendererPreferences*, Profile*, content::WebContents*))
```