### PR TITLE
Update external binaries to 1.3.0 for latest Squirrel.Mac

### DIFF
--- a/script/update-external-binaries.py
+++ b/script/update-external-binaries.py
@@ -8,7 +8,7 @@ from lib.config import get_target_arch
 from lib.util import safe_mkdir, rm_rf, extract_zip, tempdir, download
 
 
-VERSION = 'v1.1.0'
+VERSION = 'v1.3.0'
 SOURCE_ROOT = os.path.abspath(os.path.dirname(os.path.dirname(__file__)))
 FRAMEWORKS_URL = 'http://github.com/electron/electron-frameworks/releases' \
                  '/download/' + VERSION


### PR DESCRIPTION
This should bring in Squirrel.Mac https://github.com/Squirrel/Squirrel.Mac/commit/cb838776ce22bcbf41def7b9a1352f24120bab29
And potentially fix https://github.com/brave/browser-laptop/issues/2184

Previously I submitted #573 which updated to binaries v1.2.2/Squirrel.Mac v0.3.2, but that was closed in favor of using the latest binaries v1.3.0/Squirrel.Mac https://github.com/Squirrel/Squirrel.Mac/commit/cb838776ce22bcbf41def7b9a1352f24120bab29, according to the comment by @diracdeltas https://github.com/brave/muon/pull/573#issuecomment-381700071