### PR TITLE
Fix base/debug/debugging_buildflags.h not found in install_verification

### DIFF
--- a/chromium_src/chrome/browser/safe_browsing/BUILD.gn
+++ b/chromium_src/chrome/browser/safe_browsing/BUILD.gn
@@ -15,6 +15,10 @@ source_set("install_verification") {
     "//chrome/browser/install_verification/win/module_verification_common.h",
     "//electron/chromium_src/chrome/browser/install_verification/win/module_ids.cc",
   ]
+
+  public_deps = [
+    "//base",
+  ]
 }
 
 source_set("ui_extensions") {


### PR DESCRIPTION
Auditor: @bridiver