### PR TITLE
Same safe browsing page should be displayed for all lists

### DIFF
--- a/atom/browser/api/atom_api_web_contents.h
+++ b/atom/browser/api/atom_api_web_contents.h
@@ -15,6 +15,7 @@
 #include "atom/common/options_switches.h"
 #include "base/memory/memory_pressure_listener.h"
 #include "base/memory/weak_ptr.h"
+#include "chrome/browser/safe_browsing/ui_manager.h"
 #include "chrome/browser/ui/tabs/tab_strip_model_observer.h"
 #include "content/common/cursors/webcursor.h"
 #include "content/common/view_messages.h"
@@ -102,7 +103,8 @@ namespace api {
 class WebContents : public mate::TrackableObject<WebContents>,
                     public CommonWebContentsDelegate,
                     public content::WebContentsObserver,
-                    public TabStripModelObserver {
+                    public TabStripModelObserver,
+                    public safe_browsing::SafeBrowsingUIManager::Observer {
  public:
   enum Type {
     BACKGROUND_PAGE,  // A DevTools extension background page.
@@ -336,6 +338,10 @@ class WebContents : public mate::TrackableObject<WebContents>,
 
   void AuthorizePlugin(mate::Arguments* args);
 
+  // SafeBrowsingUIManager::Observer
+  void OnSafeBrowsingHit(
+    const security_interstitials::UnsafeResource& resource) override;
+
   // TabStripModelObserver
   void TabPinnedStateChanged(TabStripModel* tab_strip_model,
                              content::WebContents* contents,
@@ -532,7 +538,6 @@ class WebContents : public mate::TrackableObject<WebContents>,
                                    base::SharedMemory* shared_memory);
   bool SendIPCMessageInternal(const base::string16& channel,
                               const base::ListValue& args);
-
   AtomBrowserContext* GetBrowserContext() const;
 
   uint32_t GetNextRequestId() {

--- a/patches/master_patch.patch
+++ b/patches/master_patch.patch
@@ -512,6 +512,20 @@ index 440fdf8df66efce1b68a0463189986a6a0b0353a..7cc8fb11ecb5e2caa67e4e92d6d4526e
    // Finds TabStripModel which has a WebContents whose id is the given
    // |tab_id|, and returns the WebContents index and the TabStripModel.
    int FindTabStripModelById(int32_t tab_id, TabStripModel** model) const;
+diff --git a/chrome/browser/safe_browsing/ui_manager.cc b/chrome/browser/safe_browsing/ui_manager.cc
+index 83f3da7fdd43a0534e49bc75b4744222e17f164d..65c416743295548667c1d2c33fe895231f8c3e0b 100644
+--- a/chrome/browser/safe_browsing/ui_manager.cc
++++ b/chrome/browser/safe_browsing/ui_manager.cc
+@@ -100,7 +100,9 @@ void SafeBrowsingUIManager::CreateAndSendHitReport(
+ 
+ void SafeBrowsingUIManager::ShowBlockingPageForResource(
+     const UnsafeResource& resource) {
++#if defined(MUON_CHROMIUM_BUILD)
+   SafeBrowsingBlockingPage::ShowBlockingPage(this, resource);
++#endif
+ }
+ 
+ // static
 diff --git a/chrome/common/BUILD.gn b/chrome/common/BUILD.gn
 index 7ca361112ae6553b5d55c0118868b6592466e466..b3cbde0364a0de8e75fe06fdf86a72321078145a 100644
 --- a/chrome/common/BUILD.gn


### PR DESCRIPTION
Test:

- Checkout `safe_browsing_api` in `browser-laptop`
- Navigate to: testsafebrowsing.appspot.com
- Select any `Webpage Warnings` links and see if the safe browsing warning is displayed.