### PR TITLE
Put the control auth cookie in the watch directory too.

### DIFF
--- a/brave/utility/tor/tor_launcher_impl.cc
+++ b/brave/utility/tor/tor_launcher_impl.cc
@@ -147,6 +147,8 @@ void TorLauncherImpl::Launch(const base::FilePath& tor_bin,
     args.AppendArgPath(tor_watch_dir.AppendASCII("controlport"));
     args.AppendArg("--cookieauthentication");
     args.AppendArg("1");
+    args.AppendArg("--cookieauthfile");
+    args.AppendArgPath(tor_watch_dir.AppendASCII("control_auth_cookie"));
   }
 
   base::LaunchOptions launchopts;


### PR DESCRIPTION
This is necessary because there is an unfortunate ordering issue with
tor startup: it writes the control port first, and then the auth
cookie, but we need both in order to connect to the control port.
And it doesn't delete the auth cookie, so it can get stale.  Hence we
need to monitor writes to the auth cookie too.