### PR TITLE
 Explicitly calling `ExtensionWebContentsObserver::Initialize`

### DIFF
--- a/atom/browser/extensions/atom_extension_web_contents_observer.cc
+++ b/atom/browser/extensions/atom_extension_web_contents_observer.cc
@@ -29,6 +29,15 @@ AtomExtensionWebContentsObserver::AtomExtensionWebContentsObserver(
 
 AtomExtensionWebContentsObserver::~AtomExtensionWebContentsObserver() {}
 
+void AtomExtensionWebContentsObserver::CreateForWebContents(
+    content::WebContents* web_contents) {
+  content::WebContentsUserData<
+    AtomExtensionWebContentsObserver>::CreateForWebContents(web_contents);
+
+  // Initialize this instance if necessary.
+  FromWebContents(web_contents)->Initialize();
+}
+
 void AtomExtensionWebContentsObserver::RenderFrameCreated(
     content::RenderFrameHost* render_frame_host) {
   ExtensionWebContentsObserver::RenderFrameCreated(render_frame_host);

--- a/atom/browser/extensions/atom_extension_web_contents_observer.h
+++ b/atom/browser/extensions/atom_extension_web_contents_observer.h
@@ -24,6 +24,10 @@ class AtomExtensionWebContentsObserver
  public:
   ~AtomExtensionWebContentsObserver() override;
 
+  // Creates and initializes an instance of this class for the given
+  // |web_contents|, if it doesn't already exist.
+  static void CreateForWebContents(content::WebContents* web_contents);
+
  private:
   friend class content::WebContentsUserData<AtomExtensionWebContentsObserver>;
 


### PR DESCRIPTION
https://chromium.googlesource.com/chromium/src/+/399b6c3d211c09e1e0a003e8edb547043535bf77

fix https://github.com/brave/browser-laptop/issues/14252

Auditor: @bridiver