### PR TITLE
Check if web contents is attached before allowing it to be considered as focused

### DIFF
--- a/lib/browser/api/web-contents.js
+++ b/lib/browser/api/web-contents.js
@@ -269,7 +269,7 @@ module.exports = {
   getFocusedWebContents () {
     let focused = null
     for (let contents of binding.getAllWebContents()) {
-      if (!contents.isFocused()) continue
+      if (!contents.isFocused() || contents.attached === false) continue
       if (focused == null) focused = contents
       // Return webview web contents which may be embedded inside another
       // web contents that is also reporting as focused


### PR DESCRIPTION
Fixes https://github.com/brave/browser-laptop/issues/14197

Auditors: @petemill, @bridiver