### PR TITLE
Propagate off-the-recordness to URL request context.

### DIFF
--- a/vendor/brightray/browser/browser_context.cc
+++ b/vendor/brightray/browser/browser_context.cc
@@ -125,7 +125,7 @@ net::URLRequestContextGetter* BrowserContext::CreateRequestContext(
       this,
       static_cast<NetLog*>(BrowserClient::Get()->GetNetLog()),
       GetPath(),
-      in_memory_,
+      IsOffTheRecord(),
       BrowserThread::GetTaskRunnerForThread(BrowserThread::IO),
       protocol_handlers,
       std::move(protocol_interceptors));


### PR DESCRIPTION
This is necessary because we use `persist:tor` since for hysterical
raisins there's only one normal `private' partition with in_memory_ =
true.  We use the virtual method IsOffTheRecord() to discriminate
instead.

Fixes https://github.com/brave/muon/issues/608.
Fixes https://github.com/brave/browser-laptop/issues/14392.

Auditors: @darkdh