### PR TITLE
Remove DIR_DEFAULT_DOWNLOADS_SAFE which is covered by DownloadPrefs

### DIFF
--- a/atom/browser/api/atom_api_dialog.cc
+++ b/atom/browser/api/atom_api_dialog.cc
@@ -156,11 +156,6 @@ void ShowDialog(const file_dialog::DialogSettings& settings,
       NOTREACHED();
     }
   }
-  // This is only useful on platforms that support
-  // DIR_DEFAULT_DOWNLOADS_SAFE.
-  if (!PathService::Get(chrome::DIR_DEFAULT_DOWNLOADS_SAFE, &default_path)) {
-    NOTREACHED();
-  }
   file_type_info.include_all_files = settings.include_all_files;
   file_type_info.extension_description_overrides =
     settings.extension_description_overrides;


### PR DESCRIPTION
miscommunication in
https://github.com/brave/muon/pull/508#pullrequestreview-100614944

fix https://github.com/brave/browser-laptop/issues/14407

Auditors: @bridiver, @jumde