### PR TITLE
Use a priority queue to expire all >10min-old tor circuit records.

### DIFF
--- a/brave/browser/net/proxy_resolution/proxy_config_service_tor.h
+++ b/brave/browser/net/proxy_resolution/proxy_config_service_tor.h
@@ -27,8 +27,11 @@ const char kSocksProxy[] = "socks5";
 // Implementation of ProxyConfigService that returns a tor specific result.
 class NET_EXPORT ProxyConfigServiceTor : public ProxyConfigService {
  public:
-  // Used to cache <username, <password, timestamp>> of proxies
-  typedef std::map<std::string, std::pair<std::string, base::Time>> TorProxyMap;
+  // Used to cache <username, password> of proxies
+  struct TorProxyMap {
+    std::map<std::string, std::string> map;
+    std::priority_queue<std::pair<base::Time, std::string> > queue;
+  };
 
   explicit ProxyConfigServiceTor(const std::string& tor_proxy,
                                  const std::string& username,


### PR DESCRIPTION
Don't just expire any old entries for the site we're browsing -- that
may leave lots of other ones around in memory.