### PR TITLE
[WIP] Do not allow file/about URLs to be opened in new tab from any standard URLs

### DIFF
--- a/atom/browser/extensions/tab_helper.cc
+++ b/atom/browser/extensions/tab_helper.cc
@@ -115,6 +115,7 @@ void TabHelper::CreateTab(content::WebContents* owner,
                 content::BrowserContext* browser_context,
                 const base::DictionaryValue& create_params,
                 const GuestViewManager::WebContentsCreatedCallback& callback) {
+  std::string newTabURL = "";
   BraveBrowserContext* profile =
       BraveBrowserContext::FromBrowserContext(browser_context);
   auto guest_view_manager = static_cast<GuestViewManager*>(
@@ -130,6 +131,15 @@ void TabHelper::CreateTab(content::WebContents* owner,
   if (profile->HasParentContext()) {
     params->SetString("parent_partition",
         profile->original_context()->partition_with_prefix());
+  }
+
+  params->GetString("src", &newTabURL);
+  auto ownerURL = owner->GetLastCommittedURL();
+
+  if (GURL(newTabURL).SchemeIs(url::kFileScheme) &&
+    !(ownerURL.SchemeIs(url::kFileScheme) ||
+      ownerURL.SchemeIs(url::kAboutScheme))) {
+      params->SetString("src", url::kAboutBlankURL);
   }
 
   guest_view_manager->CreateGuest(brave::TabViewGuest::Type,


### PR DESCRIPTION
Fix https://github.com/brave/browser-laptop/issues/14522

## Test Plan:

1. Host a web-server with file: 
```
<a href="file:///<any_file_on_local_filesystem>">File URL</a>
```
2. Open webpage in Brave, right click on link and open URL in new tab.
3. `about:blank` should open instead of the given file url.