### PR TITLE
Handle file:// with net::FileProtocolHandler

### DIFF
--- a/atom/browser/atom_browser_context.cc
+++ b/atom/browser/atom_browser_context.cc
@@ -32,6 +32,7 @@
 #include "content/public/common/url_constants.h"
 #include "net/ftp/ftp_network_layer.h"
 #include "net/url_request/data_protocol_handler.h"
+#include "net/url_request/file_protocol_handler.h"
 #include "net/url_request/ftp_protocol_handler.h"
 #include "net/url_request/url_request_context.h"
 #include "net/url_request/url_request_intercepting_job_factory.h"
@@ -89,9 +90,15 @@ AtomBrowserContext::CreateURLRequestJobFactory(
       url::kDataScheme, base::WrapUnique(new net::DataProtocolHandler));
   job_factory->SetProtocolHandler(
       url::kFileScheme,
+      std::make_unique<net::FileProtocolHandler>(
+          base::CreateTaskRunnerWithTraits(
+              {base::MayBlock(), base::TaskPriority::USER_VISIBLE,
+               base::TaskShutdownBehavior::SKIP_ON_SHUTDOWN})));
+  job_factory->SetProtocolHandler(
+      "brave",
       base::WrapUnique(
           new asar::AsarProtocolHandler(base::CreateTaskRunnerWithTraits(
-              {base::MayBlock(), base::TaskPriority::USER_BLOCKING,
+              {base::MayBlock(), base::TaskPriority::USER_VISIBLE,
                base::TaskShutdownBehavior::SKIP_ON_SHUTDOWN}))));
   job_factory->SetProtocolHandler(
       url::kHttpScheme,

--- a/chromium_src/chrome/browser/ui/webui/chrome_web_ui_controller_factory.cc
+++ b/chromium_src/chrome/browser/ui/webui/chrome_web_ui_controller_factory.cc
@@ -47,7 +47,7 @@ class BraveDataSource : public content::URLDataSource,
       const std::string& path,
       const content::ResourceRequestInfo::WebContentsGetter& wc_getter,
       const GotDataCallback& callback) override {
-    GURL url = GURL("file:///" + path);
+    GURL url = GURL("brave:///" + path);
     if (!url.is_valid()) {
       DLOG(WARNING) << "Invalid webui resource: brave://" << path;
       callback.Run(


### PR DESCRIPTION
and don't covert brave:// to file://

credit the patch to @bridiver

fix brave/browser-laptop#14642

Auditor: @bridiver, @diracdeltas
