### PR TITLE
Check if file save prompt is required before saving files

### DIFF
--- a/atom/browser/atom_download_manager_delegate.cc
+++ b/atom/browser/atom_download_manager_delegate.cc
@@ -402,6 +402,15 @@ void AtomDownloadManagerDelegate::OnDownloadTargetDetermined(
     CloseWebContentsIfNeeded(web_contents);
   }
 
+  if (!download_item->ShouldPrompt()) {
+    download_item->SetSavePath(path);
+    callback.Run(path,
+                 target_info->target_disposition,
+                 download::DOWNLOAD_DANGER_TYPE_NOT_DANGEROUS, path,
+                 target_info->result);
+    return;
+  }
+
   // If we can't find proper |window| for showing save dialog, cancel
   // and cleanup current download.
   // TODO(ltilve): If we want to use WebContents internaly for download, we


### PR DESCRIPTION
Fix https://github.com/brave/browser-laptop/issues/14625

## Test Plan

1. Disable "Always Ask Where to Save Files"

- Download a file. The file prompt should not displayed and the file should be successfully downloaded.
- Change the path and download the same file again. The file prompt should not displayed and the file should be successfully downloaded at the new location

2. Enable "Always Ask Where to Save Files"

- Download a file. The file prompt should be displayed and the file should be successfully downloaded.
- Change the path and download the same file again. The file prompt should be displayed and the file should be successfully downloaded at the new location