### PR TITLE
Use new site instance for SessionStorageNamespaceImpl clone when open…

### DIFF
--- a/patches/master_patch.patch
+++ b/patches/master_patch.patch
@@ -1337,6 +1337,25 @@ index b1d214c35f075d16acfcd71576842e6b751d0697..8e9fb9fc6f5d27a106b13aad0412fc84
    DCHECK(from_rfh);
    FrameTreeNode* node =
        static_cast<RenderFrameHostImpl*>(from_rfh)->frame_tree_node();
+diff --git a/content/browser/frame_host/render_frame_host_impl.cc b/content/browser/frame_host/render_frame_host_impl.cc
+index d938013c90b630b94c2f4ee2daed542dbe437da0..05fbfe707db8afb0dcf4d3fa1a841c506e8c470c 100644
+--- a/content/browser/frame_host/render_frame_host_impl.cc
++++ b/content/browser/frame_host/render_frame_host_impl.cc
+@@ -2952,9 +2952,13 @@ void RenderFrameHostImpl::CreateNewWindow(
+     return;
+   }
+ 
++  scoped_refptr<SiteInstance> site_instance =
++    params->opener_suppressed
++      ? SiteInstance::CreateForURL(GetProcess()->GetBrowserContext(), params->target_url)
++      : GetSiteInstance();
+   // This will clone the sessionStorage for namespace_id_to_clone.
+   StoragePartition* storage_partition = BrowserContext::GetStoragePartition(
+-      GetSiteInstance()->GetBrowserContext(), GetSiteInstance());
++      site_instance->GetBrowserContext(), site_instance.get());
+   DOMStorageContextWrapper* dom_storage_context =
+       static_cast<DOMStorageContextWrapper*>(
+           storage_partition->GetDOMStorageContext());
 diff --git a/content/browser/frame_host/render_frame_message_filter.cc b/content/browser/frame_host/render_frame_message_filter.cc
 index 80fd7cf8957865e62186f394a318f912c6da4e20..a189c82b5a2d6ca6fdfb38c6eadffebd518999ea 100644
 --- a/content/browser/frame_host/render_frame_message_filter.cc


### PR DESCRIPTION
…er_suppressed(noopener) specified

because WebContentsImpl::CreateNewWindow will use target_url as new site instance

The problem was cloning original site instance cause the inconsistency
between original partition and target partition because tor browser
context enforce isolation storage so every different site has its own storage partition

fix https://github.com/brave/browser-laptop/issues/14392

Test Plan:
1. Open tor tab
2. Visit site contains rel="noopener" href (https://jsfiddle.net/dqokhmsg/)
3. Click the link
4. Brave shouldn't crash

Auditors: @bridiver, @bbondy