### PR TITLE
Do not always allow permission to enumerate device labels

### DIFF
--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -1287,13 +1287,6 @@ void WebContents::FindReply(content::WebContents* web_contents,
   Emit("found-in-page", result);
 }
 
-bool WebContents::CheckMediaAccessPermission(
-    content::RenderFrameHost* render_frame_host,
-    const GURL& security_origin,
-    content::MediaStreamType type) {
-  return true;
-}
-
 void WebContents::RequestMediaAccessPermission(
     content::WebContents* web_contents,
     const content::MediaStreamRequest& request,

--- a/atom/browser/api/atom_api_web_contents.h
+++ b/atom/browser/api/atom_api_web_contents.h
@@ -449,10 +449,6 @@ class WebContents : public mate::TrackableObject<WebContents>,
                  const gfx::Rect& selection_rect,
                  int active_match_ordinal,
                  bool final_update) override;
-  bool CheckMediaAccessPermission(
-      content::RenderFrameHost* render_frame_host,
-      const GURL& security_origin,
-      content::MediaStreamType type) override;
   void RequestMediaAccessPermission(
       content::WebContents* web_contents,
       const content::MediaStreamRequest& request,

--- a/spec/chromium-spec.js
+++ b/spec/chromium-spec.js
@@ -93,30 +93,6 @@ describe('chromium feature', function () {
     })
   })
 
-  describe('navigator.mediaDevices', function () {
-    if (process.env.TRAVIS === 'true') {
-      return
-    }
-    if (isCI && process.platform === 'linux') {
-      return
-    }
-    if (isCI && process.platform === 'win32') {
-      return
-    }
-
-    it('can return labels of enumerated devices', function (done) {
-      navigator.mediaDevices.enumerateDevices().then((devices) => {
-        const labels = devices.map((device) => device.label)
-        const labelFound = labels.some((label) => !!label)
-        if (labelFound) {
-          done()
-        } else {
-          done('No device labels found: ' + JSON.stringify(labels))
-        }
-      }).catch(done)
-    })
-  })
-
   describe('navigator.language', function () {
     it('should not be empty', function () {
       assert.notEqual(navigator.language, '')


### PR DESCRIPTION
this basically reverts
https://github.com/electron/electron/commit/fce641aab64da828cf03afd2e07b7b81333655ad.
the issue points out that this is needed for Electron apps to enumerate
device labels. however, this is not supposed to be allowed unless permission is
granted.

potential fix for https://github.com/brave/browser-laptop/issues/14889

NOTE: i haven't built or tested this