### PR TITLE
Use `BrowserProcessImpl::GetApplicationLocale` for `BraveContentBrowserClient::GetApplicationLocale`

### DIFF
--- a/brave/browser/brave_content_browser_client.cc
+++ b/brave/browser/brave_content_browser_client.cc
@@ -582,7 +582,7 @@ std::string BraveContentBrowserClient::GetApplicationLocale() {
   if (BrowserThread::CurrentlyOn(BrowserThread::IO)) {
     return io_thread_application_locale.Get();
   } else {
-    return extensions_part_->GetApplicationLocale();
+    return g_browser_process->GetApplicationLocale();
   }
 }
 


### PR DESCRIPTION
because the result of
`extension_l10n_util::CurrentLocaleOrDefault` will be normalized by
`l10n_util::NormalizeLocale` which means turning en-US to en_US

`chrome.i18n.getUILanguage` uses `RenderThread::GetLocale()` which reads
from switch `--lang` appended when renderer process created and the
value is reading from `ContentBrowserClient::GetApplicationLocale`

fix https://github.com/brave/browser-laptop/issues/11624

Auditors: @bridiver, @bbondy