### PR TITLE
Issue 14968: NULL deref while setting the window_id for the tab_helper of new_contents

### DIFF
--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -789,8 +789,14 @@ void WebContents::AddNewContents(content::WebContents* source,
     if (disposition != WindowOpenDisposition::NEW_WINDOW &&
         disposition != WindowOpenDisposition::NEW_POPUP) {
       if (!browser) {
-        // TODO(bridiver) - this should be the source owner_window
-        browser = owner_window()->browser();
+        extensions::TabHelper* source_tab_helper =
+              extensions::TabHelper::FromWebContents(source);
+        if (source_tab_helper) {
+          browser = source_tab_helper->browser();
+        } else {
+          browser = owner_window()->browser();
+        }
+        CHECK(browser);
         tab_helper->SetWindowId(browser->session_id().id());
       }
     }


### PR DESCRIPTION
Fix https://github.com/brave/browser-laptop/issues/14968

The issue was highlighted in the comment here - https://github.com/brave/muon/blob/4ffc7f014f0b8cc8853fb39e2efe35e30194abbe/atom/browser/api/atom_api_web_contents.cc#L792

For the `source` webcontents `owner_window` or `relay` will not be available if the tab is not attached. Instead we fetch the `browser` directly from the `tab_helper` to get `window_id` for the `new_contents`.  

For extensions and main window the `tab_helper` will be null, if `tab_helper` is null we fallback to the original code.

## Test Plan

poc.html

```
 <script>
  function pop (){
    open('about:blank').open('about:blank')
  }
</script>
<a href="#" onclick="pop()">Click</a>
```

1. Host poc.html on a webserver
2. Navigate to http://<server_url>/poc.html and click the hyperlink.

Expected Result: No crash

Also, verify if extensions are working correctly.

## Submitter Checklist:

- [x] Submitted a ticket for my issue if one did not already exist.
- [x] Used Github auto-closing keywords in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran git rebase -i to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [x] Request a security/privacy review as needed. (Ask a Brave employee to help if you cannot access this document.)

## Reviewer Checklist:
- [ ]  Request a security/privacy review as needed if one was not already requested.