### PR TITLE
Enable features::kSitePerProcess for chrome parity

### DIFF
--- a/atom/browser/atom_browser_main_parts.cc
+++ b/atom/browser/atom_browser_main_parts.cc
@@ -251,6 +251,11 @@ int AtomBrowserMainParts::PreCreateThreads() {
       media::kUnifiedAutoplay.name,
       base::FeatureList::OVERRIDE_DISABLE_FEATURE, field_trial);
 
+  field_trial = feature_list->GetFieldTrial(
+      features::kSitePerProcess);
+  feature_list->RegisterFieldTrialOverride(
+      features::kSitePerProcess.name,
+      base::FeatureList::OVERRIDE_ENABLE_FEATURE, field_trial);
 
   fake_browser_process_->PreCreateThreads(
       *base::CommandLine::ForCurrentProcess());

--- a/brave/browser/brave_content_browser_client.h
+++ b/brave/browser/brave_content_browser_client.h
@@ -145,6 +145,7 @@ class BraveContentBrowserClient : public atom::AtomBrowserClient {
       std::string* partition_name,
       bool* in_memory) override;
   base::FilePath GetShaderDiskCacheDirectory() override;
+  bool ShouldEnableStrictSiteIsolation() override;
 
   std::unique_ptr<base::Value> GetServiceManifestOverlay(
       base::StringPiece name) override;


### PR DESCRIPTION
Alternatively, we can trun on switches::kSitePerProcess in
browser-laptop by default, otherwise we have to provide a toggle
`switches::kDisableSiteIsolationTrials` which is equivalent to
`site-isolation-trial-opt-out` in `chrome://flags`
see `SiteIsolationPolicy::UseDedicatedProcessesForAllSites`

Auditors: @bridiver, @diracdeltas