### PR TITLE
Trying to address surface synchronization patch

### DIFF
--- a/patches/master_patch.patch
+++ b/patches/master_patch.patch
@@ -2031,14 +2031,6 @@ diff --git a/content/renderer/browser_plugin/browser_plugin.cc b/content/rendere
 index d64895137a73fe0bccc29e8081e0a16c4657a86f..58befaf094e95827a5126e0abfa55d30a9e13340 100644
 --- a/content/renderer/browser_plugin/browser_plugin.cc
 +++ b/content/renderer/browser_plugin/browser_plugin.cc
-@@ -105,6 +105,7 @@ BrowserPlugin::BrowserPlugin(
-     delegate_->SetElementInstanceID(browser_plugin_instance_id_);
- 
-   enable_surface_synchronization_ = features::IsSurfaceSynchronizationEnabled();
-+  enable_surface_synchronization_ = false;
- }
- 
- BrowserPlugin::~BrowserPlugin() {
 @@ -219,7 +220,12 @@ void BrowserPlugin::Detach() {
  
    attached_ = false;


### PR DESCRIPTION
Trying to address https://github.com/brave/browser-laptop/issues/15025

Removing these patches from browser_plugin.cc:
- https://github.com/brave/muon/commit/bbf2817aef4e43b895e31af231189fd9ce2df3e2
- https://github.com/brave/muon/commit/416dc9c2c570b2207baa0e5f1d4d927f223aabe5

Most of the above patches have already been removed (after single webview) from browser_plugin.cc
Chromium 68 has a few patches related to surface synchronization, such as this:
https://chromium.googlesource.com/chromium/src/+/98d76dade64f938d939b7930e1de5460b564c2e2%5E%21/

The above Muon patches were to solve https://github.com/brave/browser-laptop/issues/13982
I compiled this change in release mode + ran with 25 tabs (switching tabs with mouse/keyboard). I quit, relaunched, etc. Also turned off tab preview + used debug menu to manually discard tabs and switch back to them. Didn't notice any of the webviews get locked
Not sure if this solves the problem, but this patch might not be needed anymore

Auditors:
@bridiver, @petemill