### PR TITLE
Add API method: electron.app.getCountryName

### DIFF
--- a/atom/browser/api/atom_api_app.cc
+++ b/atom/browser/api/atom_api_app.cc
@@ -68,6 +68,10 @@
 #include "base/strings/utf_string_conversions.h"
 #endif
 
+#if defined(OS_MACOSX)
+#import <CoreFoundation/CoreFoundation.h>
+#endif
+
 #if BUILDFLAG(ENABLE_EXTENSIONS)
 #include "brave/browser/api/brave_api_extension.h"
 #include "chrome/browser/chrome_notification_types.h"
@@ -730,6 +734,23 @@ std::string App::GetCountryName() {
   base::WideToUTF8(localized_country_name,
     country_name_length,
     &country);
+
+  #elif defined(OS_MACOSX)
+  // for more info, see:
+  // https://developer.apple.com/documentation/corefoundation/1543547-cflocalegetvalue?language=objc
+  // https://developer.apple.com/documentation/corefoundation/cflocalekey?language=objc
+  CFLocaleRef cflocale = CFLocaleCopyCurrent();
+  CFStringRef country_code = (CFStringRef)CFLocaleGetValue(
+    cflocale, kCFLocaleCountryCode);
+  CFIndex kCountryNameLength = CFStringGetLength(country_code) + 1;
+  char localized_country_name[kCountryNameLength];
+  if (CFStringGetCString(country_code, localized_country_name,
+    kCountryNameLength, kCFStringEncodingUTF8)) {
+    country = std::string(localized_country_name);
+  }
+
+  #elif defined(OS_LINUX)
+  // ..TODO..
   #endif
 
   return country;

--- a/atom/browser/api/atom_api_app.cc
+++ b/atom/browser/api/atom_api_app.cc
@@ -72,6 +72,10 @@
 #import <CoreFoundation/CoreFoundation.h>
 #endif
 
+#if defined(OS_LINUX)
+#include <locale.h>
+#endif
+
 #if BUILDFLAG(ENABLE_EXTENSIONS)
 #include "brave/browser/api/brave_api_extension.h"
 #include "chrome/browser/chrome_notification_types.h"
@@ -750,7 +754,11 @@ std::string App::GetCountryName() {
   }
 
   #elif defined(OS_LINUX)
-  // ..TODO..
+  // for more info, see:
+  // https://en.cppreference.com/w/cpp/locale/setlocale
+  setlocale(LC_ALL, "");
+  country = std::string(setlocale(LC_ALL, NULL));
+
   #endif
 
   return country;

--- a/atom/browser/api/atom_api_app.cc
+++ b/atom/browser/api/atom_api_app.cc
@@ -714,6 +714,27 @@ void App::SetLocale(std::string locale) {
   g_browser_process->SetApplicationLocale(locale);
 }
 
+std::string App::GetCountryName() {
+  std::string country = "";
+
+  #if defined(OS_WIN)
+  // for more info, see:
+  // https://docs.microsoft.com/en-us/windows/desktop/api/winnls/nf-winnls-getlocaleinfoex
+  // https://docs.microsoft.com/en-us/windows/desktop/Intl/locale-slocalized-constants
+  WCHAR localized_country_name[80];
+  int country_name_length = GetLocaleInfoEx(
+    LOCALE_NAME_USER_DEFAULT,
+    LOCALE_SLOCALIZEDCOUNTRYNAME,
+    (LPWSTR)&localized_country_name,
+    sizeof(localized_country_name) / sizeof(WCHAR));
+  base::WideToUTF8(localized_country_name,
+    country_name_length,
+    &country);
+  #endif
+
+  return country;
+}
+
 bool App::GetBooleanPref(const std::string& path) {
   return g_browser_process->local_state()->GetBoolean(path);
 }
@@ -954,6 +975,7 @@ void App::BuildPrototype(
       .SetMethod("setDesktopName", &App::SetDesktopName)
       .SetMethod("getLocale", &App::GetLocale)
       .SetMethod("setLocale", &App::SetLocale)
+      .SetMethod("getCountryName", &App::GetCountryName)
       .SetMethod("getBooleanPref", &App::GetBooleanPref)
       .SetMethod("setBooleanPref", &App::SetBooleanPref)
       .SetMethod("makeSingleInstance", &App::MakeSingleInstance)

--- a/atom/browser/api/atom_api_app.h
+++ b/atom/browser/api/atom_api_app.h
@@ -117,6 +117,7 @@ class App : public AtomBrowserClient::Delegate,
   void SetDesktopName(const std::string& desktop_name);
   void SetLocale(std::string);
   std::string GetLocale();
+  std::string GetCountryName();
   void SetBooleanPref(const std::string& path, bool value);
   bool GetBooleanPref(const std::string& path);
   bool MakeSingleInstance(


### PR DESCRIPTION
To be used to properly solve https://github.com/brave/browser-laptop/issues/14647

- Was unable to use the existing `electron.app.getLocale` method because it would return the language (not the country)
- I also looked at existing ICU methods and methods in the l10n/i18n helpers in Chromium's `base` namespace, but those all returned empty string for locale (as if it wasn't initialized properly)
- I briefly looked at node/native node modules and it looked too messy and unfruitful to go that route

This PR can be merged into C68 AND C69. ex: would be good to have a 8.0.10 and a 8.1.x build 😄 