### PR TITLE
Update incognito session initialization

### DIFF
--- a/atom/browser/api/atom_api_user_prefs.cc
+++ b/atom/browser/api/atom_api_user_prefs.cc
@@ -60,51 +60,51 @@ Profile* UserPrefs::profile() {
 }
 
 void UserPrefs::RegisterStringPref(const std::string& path,
-    const std::string& default_value, bool overlay) {
+    const std::string& default_value, bool persist) {
   profile()->pref_registry()->RegisterStringPref(path, default_value);
-  if (overlay)
-    profile()->AddOverlayPref(path);
+  if (persist)
+    profile()->RegisterPersistentPref(path);
 }
 
 void UserPrefs::RegisterDictionaryPref(const std::string& path,
-    const base::DictionaryValue& default_value, bool overlay) {
+    const base::DictionaryValue& default_value, bool persist) {
   std::unique_ptr<base::DictionaryValue> copied(
       default_value.CreateDeepCopy());
   profile()->pref_registry()->
       RegisterDictionaryPref(path, std::move(copied));
-  if (overlay)
-    profile()->AddOverlayPref(path);
+  if (persist)
+    profile()->RegisterPersistentPref(path);
 }
 
 void UserPrefs::RegisterListPref(const std::string& path,
-    const base::ListValue& default_value, bool overlay) {
+    const base::ListValue& default_value, bool persist) {
   std::unique_ptr<base::ListValue> copied(
       default_value.CreateDeepCopy());
   profile()->pref_registry()->
       RegisterListPref(path, std::move(copied));
-  if (overlay)
-    profile()->AddOverlayPref(path);
+  if (persist)
+    profile()->RegisterPersistentPref(path);
 }
 
 void UserPrefs::RegisterBooleanPref(const std::string& path,
-    bool default_value, bool overlay) {
+    bool default_value, bool persist) {
   profile()->pref_registry()->RegisterBooleanPref(path, default_value);
-  if (overlay)
-    profile()->AddOverlayPref(path);
+  if (persist)
+    profile()->RegisterPersistentPref(path);
 }
 
 void UserPrefs::RegisterIntegerPref(const std::string& path,
-    int default_value, bool overlay) {
+    int default_value, bool persist) {
   profile()->pref_registry()->RegisterIntegerPref(path, default_value);
-  if (overlay)
-    profile()->AddOverlayPref(path);
+  if (persist)
+    profile()->RegisterPersistentPref(path);
 }
 
 void UserPrefs::RegisterDoublePref(const std::string& path,
-    double default_value, bool overlay) {
+    double default_value, bool persist) {
   profile()->pref_registry()->RegisterDoublePref(path, default_value);
-  if (overlay)
-    profile()->AddOverlayPref(path);
+  if (persist)
+    profile()->RegisterPersistentPref(path);
 }
 
 std::string UserPrefs::GetStringPref(const std::string& path) {

--- a/brave/browser/brave_browser_context.cc
+++ b/brave/browser/brave_browser_context.cc
@@ -532,21 +532,18 @@ void BraveBrowserContext::CreateProfilePrefs(
   bool async = false;
 
   if (IsOffTheRecord()) {
-    overlay_pref_names_.push_back("app_state");
-    overlay_pref_names_.push_back(extensions::pref_names::kPrefContentSettings);
-    overlay_pref_names_.push_back(prefs::kPartitionPerHostZoomLevels);
     std::unique_ptr<PrefValueStore::Delegate> delegate = nullptr;
     user_prefs_ =
         original_context()->user_prefs()->CreateIncognitoPrefService(
-            extension_prefs, overlay_pref_names_, std::move(delegate));
+            extension_prefs, persistent_pref_names_, std::move(delegate));
     user_prefs::UserPrefs::Set(this, user_prefs_.get());
   } else if (HasParentContext()) {
-    // overlay pref names only apply to incognito
+    // persistent pref names only apply to incognito
     std::unique_ptr<PrefValueStore::Delegate> delegate = nullptr;
-    std::vector<const char*> overlay_pref_names;
+    std::vector<const char*> persistent_pref_names;
     user_prefs_ =
         original_context()->user_prefs()->CreateIncognitoPrefService(
-            extension_prefs, overlay_pref_names, std::move(delegate));
+            extension_prefs, persistent_pref_names, std::move(delegate));
     user_prefs::UserPrefs::Set(this, user_prefs_.get());
   } else {
     pref_registry_->RegisterDictionaryPref("app_state");

--- a/brave/browser/brave_browser_context.h
+++ b/brave/browser/brave_browser_context.h
@@ -129,8 +129,8 @@ class BraveBrowserContext : public Profile {
   std::string partition_with_prefix();
   base::WaitableEvent* ready() { return ready_.get(); }
 
-  void AddOverlayPref(const std::string name) override {
-    overlay_pref_names_.push_back(name.c_str()); }
+  void RegisterPersistentPref(const std::string name) override {
+    persistent_pref_names_.push_back(name.c_str()); }
 
   scoped_refptr<autofill::AutofillWebDataService>
     GetAutofillWebdataService() override;
@@ -178,7 +178,7 @@ class BraveBrowserContext : public Profile {
   scoped_refptr<user_prefs::PrefRegistrySyncable> pref_registry_;
   std::unique_ptr<sync_preferences::PrefServiceSyncable> user_prefs_;
   std::unique_ptr<PrefChangeRegistrar> user_prefs_registrar_;
-  std::vector<const char*> overlay_pref_names_;
+  std::vector<const char*> persistent_pref_names_;
 
   std::unique_ptr<content::HostZoomMap::Subscription> track_zoom_subscription_;
     std::unique_ptr<ChromeZoomLevelPrefs::DefaultZoomLevelSubscription>

--- a/chromium_src/chrome/browser/profiles/profile.h
+++ b/chromium_src/chrome/browser/profiles/profile.h
@@ -157,7 +157,7 @@ class Profile : public atom::AtomBrowserContext {
 
   virtual user_prefs::PrefRegistrySyncable* pref_registry() const = 0;
 
-  virtual void AddOverlayPref(const std::string name) = 0;
+  virtual void RegisterPersistentPref(const std::string name) = 0;
 
   virtual scoped_refptr<autofill::AutofillWebDataService>
     GetAutofillWebdataService() = 0;


### PR DESCRIPTION
With https://chromium.googlesource.com/chromium/src/+/f623bafe9c5b8cbd1d63c4d7c9b69de172552df5, the values being registered in a session were changed from an exclusion (ex: which values to NOT put in `OverlayUserPrefStore`) to an inclusion (ex: which values to PERSIST, even in an incognito profile)

Fixes https://github.com/brave/browser-laptop/issues/15191