### PR TITLE
security: remove getBuiltin() and depending functions

### DIFF
--- a/lib/renderer/api/remote.js
+++ b/lib/renderer/api/remote.js
@@ -292,11 +292,6 @@ ipcRenderer.on('ELECTRON_RENDERER_RELEASE_CALLBACK', function (event, id) {
 
 var binding = {}
 
-// Alias to remote.require('electron').xxx.
-binding.getBuiltin = function (module) {
-  return metaToValue(ipcRenderer.sendSync('ELECTRON_BROWSER_GET_BUILTIN', module))
-}
-
 // Get current BrowserWindow.
 binding.getCurrentWindow = function () {
   return metaToValue(ipcRenderer.sendSync('ELECTRON_BROWSER_CURRENT_WINDOW'))
@@ -329,16 +324,6 @@ binding.registerAllWindowTabEvents = function (listener) {
 
 binding.unregisterEvents = function (tabID, listener) {
   GuestViewInternal.removeListener(tabID, listener)
-}
-
-const deprecatedRemoteAPIs = ['Menu', 'shell', 'screen', 'clipboard', 'session', 'BrowserWindow']
-for (var i = 0, len = deprecatedRemoteAPIs.length; i < len; i++) {
-  const name = deprecatedRemoteAPIs[i]
-  Object.defineProperty(binding, name, {
-    get: function () {
-      return binding.getBuiltin(name)
-    }
-  })
 }
 
 exports.$set('registerEvents', binding.registerEvents)


### PR DESCRIPTION
In the spirit of #644

getBuiltin() allows you to get any arbitrary electron module, such as `app`.

Page 9 - `app = ipcRenderer.sendSync('ELECTRON_BROWSER_GET_BUILTIN', 'app') `
https://www.blackhat.com/docs/us-17/thursday/us-17-Carettoni-Electronegativity-A-Study-Of-Electron-Security-wp.pdf