### PR TITLE
Issue: 15232 AllowScript should use atom::ContentSettingsManager like other Allow* methods in the observer

### DIFF
--- a/chromium_src/chrome/renderer/content_settings_observer.cc
+++ b/chromium_src/chrome/renderer/content_settings_observer.cc
@@ -432,11 +432,13 @@ bool ContentSettingsObserver::AllowScript(bool enabled_per_settings) {
   // IsWhitelistedForContentSettings(); if there is only the default rule
   // allowing all scripts, it's quicker this way.
   bool allow = true;
-  if (content_setting_rules_) {
-    ContentSetting setting = GetContentSettingFromRules(
-        content_setting_rules_->script_rules, frame,
-        url::Origin(frame->GetDocument().GetSecurityOrigin()).GetURL());
-    allow = setting != CONTENT_SETTING_BLOCK;
+  if (content_settings_manager_->content_settings()) {
+    allow =
+        content_settings_manager_->GetSetting(
+          ContentSettingsManager::GetOriginOrURL(render_frame()->GetWebFrame()),
+          url::Origin(frame->GetDocument().GetSecurityOrigin()).GetURL(),
+          "javascript",
+          allow) != CONTENT_SETTING_BLOCK;
   }
   allow = allow || IsWhitelistedForContentSettings();
 


### PR DESCRIPTION
fix https://github.com/brave/browser-laptop/issues/15232

## Test Plan

1. Open Brave and navigate to `https://peltate-worth.000webhostapp.com/world.html`
2. Enable `Block Scripts` for the domain
3. Click on `Show Message` - `alert` box should not be displayed.